### PR TITLE
Pretty print JSON on development environments

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,7 @@ export function send (res, code, obj = null) {
       // we stringify before setting the header
       // in case `JSON.stringify` throws and a
       // 500 has to be sent instead
-      str = JSON.stringify(obj);
+      str = JSON.stringify(obj, null, DEV ? 2 : 0);
       res.setHeader('Content-Type', 'application/json');
     } else {
       str = obj;


### PR DESCRIPTION
This patch makes it so that the JSON output returned by the server gets pretty-printed whenever `NODE_ENV=development`.
