### PR TITLE
Fix execution instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,7 +29,7 @@ export default async function (req, res) {
 To run the microservice on port `3000`, use the `micro` command:
 
 ```bash
-$ micro -p 3000 sleep.js
+$ micro sleep.js -p 3000
 ```
 
 ## Documentation


### PR DESCRIPTION
The current order results in:

```
➜  micro-sample  micro -p 3000 index.js 
module.js:340
    throw err;
    ^

Error: Cannot find module '/{path}/3000'
```
