### PR TITLE
Optimize `JSON.stringify` performance in V8.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,15 @@ export function send (res, code, obj = null) {
       // we stringify before setting the header
       // in case `JSON.stringify` throws and a
       // 500 has to be sent instead
-      str = JSON.stringify(obj, null, DEV ? 2 : 0);
+
+      // the `JSON.stringify` call is split into
+      // two cases as `JSON.stringify` is optimized
+      // in V8 if called with only one argument
+      if (DEV) {
+        str = JSON.stringify(obj, null, 2);
+      } else {
+        str = JSON.stringify(obj);
+      }
       res.setHeader('Content-Type', 'application/json');
     } else {
       str = obj;


### PR DESCRIPTION
Older versions of V8 have a bug [1](https://bugs.chromium.org/p/v8/issues/detail?id=4730) where using empty `replacer` or `space` arguments decreases performance.
