### PR TITLE
Add main library to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
       "build/test/*.js"
     ]
   },
+  "main": "build/lib/index.js",
   "scripts": {
     "gulp": "gulp",
     "test": "gulp test"


### PR DESCRIPTION
Currently you can't require `micro` because it doesn't find the library.

Fixes #28 
