### PR TITLE
gulpfile: fix 0.12 tests - don't use arrow funcs

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,5 +45,7 @@ gulp.task('lint', function () {
   .pipe(eslint.failAfterError())
 })
 
-gulp.task('clean', () => del(['build']))
+gulp.task('clean', function () {
+  del(['build'])
+})
 gulp.task('default', ['lint', 'compile', 'test'])


### PR DESCRIPTION
convert the last function to ES5
