### PR TITLE
License

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "bugs": {
     "url": "https://github.com/zeit/micro/issues"
   },
+  "license": "MIT",
   "babel": {
     "presets": [
       "es2015"


### PR DESCRIPTION
The `micro` doesn't provide a license information except for README like a LICENSE file or a "license" field in a package.json.

This change is putting "license" field in the package.json simply.

Step to verify:

```
$ npm i -g license-checker
$ npm i micro
$ license-checker --onlyunknown
├─ micro@2.1.0
│  ├─ licenses: UNKNOWN
│  └─ repository: https://github.com/zeit/micro
└─ ms@0.7.1
   ├─ licenses: MIT*
   ├─ repository: https://github.com/guille/ms.js
   └─ licenseFile: /Users/okuryu/work/test-micro/node_modules/ms/LICENSE
```
