### PR TITLE
update micro-core and add tests for return

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,19 @@ Read more about [Transpilation](#transpilation) to understand what transformatio
   }
   ```
 
+#### return
+
+**`return val;`**
+
+- Returning `val` from your function is shorthand for: `send(res, 200, val)`.
+- Example
+
+  ```js
+  export default function (req, res) {
+    return {message: 'Hello!'};
+  }
+  ```
+
 #### sendError
 
 **`send(req, res, error)`**

--- a/README.md
+++ b/README.md
@@ -155,6 +155,19 @@ Read more about [Transpilation](#transpilation) to understand what transformatio
   }
   ```
 
+- Returning a promise works as well!
+- Example
+
+  ```js
+  import sleep from 'then-sleep';
+  export default async function(req, res) => {
+    return new Promise(async (resolve) => {
+      await sleep(100);
+      resolve('I Promised');
+    });
+  }
+  ```
+
 #### sendError
 
 **`send(req, res, error)`**

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "babel-runtime": "6.6.1",
     "commander": "2.9.0",
     "media-typer": "0.3.0",
-    "micro-core": "0.1.0",
+    "micro-core": "0.3.0",
     "raw-body": "2.1.5"
   },
   "files": [

--- a/test/index.js
+++ b/test/index.js
@@ -40,6 +40,50 @@ test('send(<Number>)', async t => {
   }
 })
 
+test('return <String>', async t => {
+  const fn = async (req, res) => {
+    return 'woot'
+  }
+
+  const url = await listen(fn)
+  const res = await request(url)
+
+  t.same(res, 'woot')
+})
+
+test('sync return <String>', async t => {
+  const fn = (req, res) => {
+    return 'argon'
+  }
+
+  const url = await listen(fn)
+  const res = await request(url)
+
+  t.same(res, 'argon')
+})
+
+test('return empty string', async t => {
+  const fn = async (req, res) => {
+    return ''
+  }
+
+  const url = await listen(fn)
+  const res = await request(url)
+
+  t.same(res, '')
+})
+
+test('return <Object>', async t => {
+  const fn = async (req, res) => {
+    return { a: 'b' };
+  }
+
+  const url = await listen(fn)
+  const res = await request(url, { json: true })
+
+  t.same(res, { a: 'b' })
+})
+
 test('throw with code', async t => {
   const fn = async (req, res) => {
     await sleep(100)

--- a/test/index.js
+++ b/test/index.js
@@ -51,6 +51,20 @@ test('return <String>', async t => {
   t.same(res, 'woot')
 })
 
+test('return <Promise>', async t => {
+  const fn = async (req, res) => {
+    return new Promise(async (resolve) => {
+      await sleep(100)
+      resolve('I Promise')
+    });
+  }
+
+  const url = await listen(fn)
+  const res = await request(url)
+
+  t.same(res, 'I Promise')
+})
+
 test('sync return <String>', async t => {
   const fn = (req, res) => {
     return 'argon'


### PR DESCRIPTION
This updates `micro-core` to `0.3.0` to add support for return values as documented here: https://github.com/zeit/micro-core/pull/3
