### PR TITLE
Add buffer and stream support to `send`

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,11 @@ Read more about [Transpilation](#transpilation) to understand what transformatio
 - Use `import { send } from 'micro'` or `require('micro').send`.
 - `statusCode` is a `Number` with the HTTP error code, and must always be supplied.
 - If `data` is supplied it is sent in the response. Different input types are processed appropriately, and `Content-Type` and `Content-Length` are automatically set.
-  - `Stream`: `data` is piped as an `octet-stream`.
+  - `Stream`: `data` is piped as an `octet-stream`. Note: it is _your_ responsibility to handle the `error` event in this case (usually, simply logging the error and aborting the response is enough).
   - `Buffer`: `data` is written as an `octet-stream`.
   - `object`: `data` is serialized as JSON.
   - `string`: `data` is written as-is.
-- If JSON serialization fails (for example, if a cyclical reference is found), a `400` error is thrown. If a `Stream` emits an `error` event, a `500` error is thrown. See [Error Handling](#error-handling).
+- If JSON serialization fails (for example, if a cyclical reference is found), a `400` error is thrown. See [Error Handling](#error-handling).
 - Example
 
   ```js

--- a/README.md
+++ b/README.md
@@ -138,8 +138,12 @@ Read more about [Transpilation](#transpilation) to understand what transformatio
 
 - Use `import { send } from 'micro'` or `require('micro').send`.
 - `statusCode` is a `Number` with the HTTP error code, and must always be supplied.
-- If `data` is supplied and is an `object`, it's automatically serialized as JSON. `Content-Type` and `Content-Length` are automatically set.
-- If JSON serialization fails (for example, if a cyclical reference is found), a `400` error is thrown (see [Error Handling](#error-handling)).
+- If `data` is supplied it is sent in the response. Different input types are processed appropriately, and `Content-Type` and `Content-Length` are automatically set.
+  - `Stream`: `data` is piped as an `octet-stream`.
+  - `Buffer`: `data` is written as an `octet-stream`.
+  - `object`: `data` is serialized as JSON.
+  - `string`: `data` is written as-is.
+- If JSON serialization fails (for example, if a cyclical reference is found), a `400` error is thrown. If a `Stream` emits an `error` event, a `500` error is thrown. See [Error Handling](#error-handling).
 - Example
 
   ```js

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "gulp-ext": "1.0.0",
     "gulp-task-listing": "1.0.1",
     "request-promise": "2.0.0",
+    "resumer": "0.0.0",
     "then-sleep": "1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "babel-runtime": "6.6.1",
     "commander": "2.9.0",
     "media-typer": "0.3.0",
-    "micro-core": "0.3.0",
+    "micro-core": "0.4.0",
     "raw-body": "2.1.5"
   },
   "files": [

--- a/test/index.js
+++ b/test/index.js
@@ -174,7 +174,7 @@ test('throw (500)', async t => {
   }
 })
 
-test('send(200, <Stream>) with error', async t => {
+test('send(200, <Stream>) with error on same tick', async t => {
   const fn = async (req, res) => {
     const stream = resumer().queue('error-stream')
     send(res, 200, stream)

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,7 @@ import { json, send } from 'micro-core'
 import request from 'request-promise'
 import listen from './_listen'
 import sleep from 'then-sleep'
+import resumer from 'resumer'
 
 test('send(200, <String>)', async t => {
   const fn = async (req, res) => {
@@ -24,6 +25,28 @@ test('send(200, <Object>)', async t => {
   const res = await request(url, { json: true })
 
   t.same(res, { a: 'b' })
+})
+
+test('send(200, <Buffer>)', async t => {
+  const fn = async (req, res) => {
+    send(res, 200, new Buffer('muscle'))
+  }
+
+  const url = await listen(fn)
+  const res = await request(url)
+
+  t.same(res, 'muscle')
+})
+
+test('send(200, <Stream>)', async t => {
+  const fn = async (req, res) => {
+    send(res, 200, resumer().queue('waterfall').end())
+  }
+
+  const url = await listen(fn)
+  const res = await request(url)
+
+  t.same(res, 'waterfall')
 })
 
 test('send(<Number>)', async t => {
@@ -98,6 +121,28 @@ test('return <Object>', async t => {
   t.same(res, { a: 'b' })
 })
 
+test('return <Buffer>', async t => {
+  const fn = async (req, res) => {
+    return new Buffer('Hammer')
+  }
+
+  const url = await listen(fn)
+  const res = await request(url)
+
+  t.same(res, 'Hammer')
+})
+
+test('return <Stream>', async t => {
+  const fn = async (req, res) => {
+    return resumer().queue('River').end()
+  }
+
+  const url = await listen(fn)
+  const res = await request(url)
+
+  t.same(res, 'River')
+})
+
 test('throw with code', async t => {
   const fn = async (req, res) => {
     await sleep(100)
@@ -124,6 +169,25 @@ test('throw (500)', async t => {
 
   try {
     await request(url)
+  } catch (err) {
+    t.same(err.statusCode, 500)
+  }
+})
+
+test('send(200, <Stream>) with error', async t => {
+  const fn = async (req, res) => {
+    const stream = resumer().queue('error-stream')
+    send(res, 200, stream)
+
+    stream.emit('error', new Error('500 from test (expected)'))
+    stream.end()
+  }
+
+  const url = await listen(fn)
+
+  try {
+    await request(url)
+    t.fail()
   } catch (err) {
     t.same(err.statusCode, 500)
   }


### PR DESCRIPTION
Once a release of [micro-core](https://github.com/zeit/micro-core) is made, I'll update the dependency here. Tests will fail until then.
