### PR TITLE
fixing issues preventing `micro` cli to work properly

### DIFF
--- a/bin/micro
+++ b/bin/micro
@@ -6,7 +6,6 @@ import { resolve } from 'path'
 
 // babel
 import preset2015 from 'babel-preset-es2015'
-import syntaxAsync from 'babel-plugin-syntax-async-functions'
 import transformAsync from 'babel-plugin-transform-async-to-generator'
 import transformRuntime from 'babel-plugin-transform-runtime'
 import alias from 'babel-plugin-module-alias'
@@ -38,7 +37,6 @@ if (!flags.noBabel) {
   require('babel-register')({
     presets: [preset2015],
     plugins: [
-      syntaxAsync,
       transformAsync,
       transformRuntime,
       [alias, [

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/zeit/micro",
   "dependencies": {
-    "args": "1.2.0",
+    "args": "1.2.1",
     "babel-plugin-module-alias": "1.1.1",
     "babel-plugin-transform-async-to-generator": "6.4.6",
     "babel-plugin-transform-runtime": "6.7.5",


### PR DESCRIPTION
Currently 4.0.0 and 4.1.0 were broken due to dependency problems, this PR fixes both issues.

Fixes #50 
