### PR TITLE
Use `main` as entry point for application if file isn't passed as argument

### DIFF
--- a/bin/micro
+++ b/bin/micro
@@ -19,6 +19,13 @@ const flags = args.parse(process.argv)
 let file = args.sub.pop()
 
 if (!file) {
+  try {
+    let packageJson = require(resolve(process.cwd(), 'package.json'))
+    file = packageJson.main
+  } catch (e) {}
+}
+
+if (!file) {
   console.error(`\n> \u001b[31mError!\u001b[39m Please supply a file.`)
   args.showHelp()
   process.exit(1)
@@ -46,7 +53,14 @@ if (!flags.noBabel) {
   })
 }
 
-const mod = require(file).default
+let mod
+
+try {
+  mod = require(file).default
+} catch (e) {
+  console.error(`> \u001b[31mError!\u001b[39m "${file}" does not exist.`)
+  process.exit(1)
+}
 
 if ('function' !== typeof mod) {
   console.error(`> \u001b[31mError!\u001b[39m "${file}" does not export a function.`)

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "gulp-ext": "1.0.0",
     "gulp-task-listing": "1.0.1",
     "request-promise": "2.0.0",
-    "resumer": "0.0.0",
     "then-sleep": "1.0.1"
   }
 }


### PR DESCRIPTION
It will look for `main` property in package.json and will try to use it as main file when argument isn't provided.

Fixes #47 
