### PR TITLE
Allow custom Content-Type for Buffer/Stream returned from fn.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -57,11 +57,17 @@ function send(res, code, obj = null) {
 
   if (null !== obj) {
     if (Buffer.isBuffer(obj)) {
-      res.setHeader('Content-Type', 'application/octet-stream')
+      if (!res.getHeader('Content-Type')) {
+        res.setHeader('Content-Type', 'application/octet-stream')
+      }
+
       res.setHeader('Content-Length', obj.length)
       res.end(obj)
     } else if (isStream(obj)) {
-      res.setHeader('Content-Type', 'application/octet-stream')
+      if (!res.getHeader('Content-Type')) {
+        res.setHeader('Content-Type', 'application/octet-stream')
+      }
+
       obj.pipe(res)
     } else {
       let str


### PR DESCRIPTION
Currently the custom `Content-Type` in fn (for example):

``` javascript
const fetch = require('node-fetch')

module.exports = function (req, res) {
  return fetch('https://httpbin.org/ip').then(r => {
    res.setHeader('Content-Type', r.headers.get('Content-Type'))
    return r.body
  })
}
```

would be overridden by [`micro.send()` method](https://github.com/zeit/micro/blob/6abdac71cae984718c7cd1f582e3147d07d9be7a/lib/index.js#L64). This PR fix this :)
