### PR TITLE
Check for undefined values in return, too

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,7 @@ async function run(req, res, fn, onError) {
     const val = await fn(req, res)
 
     // return a non-null value -> send with 200
-    if (null !== val) {
+    if (null != val) {
       send(res, 200, val)
     }
   } catch (err) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,7 @@ async function run(req, res, fn, onError) {
     const val = await fn(req, res)
 
     // return a non-null value -> send with 200
-    if (null != val) {
+    if (null !== val && undefined !== val) {
       send(res, 200, val)
     }
   } catch (err) {


### PR DESCRIPTION
If you end a handler with `send(res, 201, { ok: true })` the send shouldn't be
called twice. This confuses loggers that override `res.end` and log two
requests instead of one.
