### PR TITLE
Allows micro cli to use custom onError.

### DIFF
--- a/bin/micro
+++ b/bin/micro
@@ -55,9 +55,11 @@ if ('/' !== file[0]) {
 require('async-to-gen/register')
 
 let mod
+let onError
 
 try {
   mod = require(file);
+  onError = mod.onError
   if (mod && 'object' === typeof mod) {
     mod = mod.default;
   }
@@ -71,8 +73,12 @@ if ('function' !== typeof mod) {
   process.exit(1)
 }
 
+if ('function' !== typeof onError) {
+  onError = null
+}
+
 const { port, host } = args
-serve(mod).listen(port, host, err => {
+serve(mod, { onError }).listen(port, host, err => {
   if (err) {
     console.error('micro:', err.stack)
     process.exit(1)


### PR DESCRIPTION
The micro cli now will read in `exports.onError` and pass it to `serve` if it exists. Here is an example:

``` javascript
module.exports = exports = async function (request, response) {
  throw createError(405, 'Method Not Allowed');
};

exports.onError = function (req, res, { statusCode, message, stack }) {
  send(res, statusCode, {
    statusCode,
    message
  });
}
```

Please let me know if this is something you would be open to merging. If so, I will add tests and documentation. Thanks!
