### PR TITLE
Remove duplicated async-to-gen

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   },
   "homepage": "https://github.com/zeit/micro#readme",
   "devDependencies": {
-    "async-to-gen": "1.0.5",
     "ava": "^0.16.0",
     "request": "^2.74.0",
     "request-promise": "^4.1.1",


### PR DESCRIPTION
It's defined on the `dependencies` field too.
