### PR TITLE
Deprecates `onError` and removes references from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,12 @@ $ npm start
 ### API
 
 #### micro
-**`micro(fn, { onError = null })`**
+**`micro(fn)`**
 
 - This function is exposed as the `default` export.
 - Use `require('micro')`.
 - Returns a [`http.Server`](https://nodejs.org/dist/latest-v4.x/docs/api/http.html#http_class_http_server) that uses the provided `fn` as the request handler.
 - The supplied function is run with `await`. It can be `async`!
-- The `onError` function is invoked with `req, res, err` if supplied (see [Error Handling](#error-handling))
 - Example:
 
   ```js
@@ -166,7 +165,7 @@ $ npm start
 **`sendError(req, res, error)`**
 
 - Use `require('micro').sendError`.
-- Used as the default handler for `onError`.
+- Used as the default handler for errors thrown.
 - Automatically sets the status code of the response based on `error.statusCode`.
 - Sends the `error.message` as the body.
 - During development (when `NODE_ENV` is set to `'development'`), stacks are printed out with `console.error` and also sent in responses.
@@ -234,18 +233,7 @@ If the error is based on another error that **Micro** caught, like a `JSON.parse
 
 If a generic error is caught, the status will be set to `500`.
 
-In order to set up your own error handling mechanism, you can pass a custom `onError` function to micro:
-
-```js
-const myErrorHandler = async (req, res, err) => {
-  // your own logging here
-  res.writeHead(500);
-  res.end('error!');
-};
-micro(handler, { onError: myErrorHandler });
-```
-
-**However**, generally you want to instead use simple composition:
+In order to set up your own error handling mechanism, you can use composition in your handler:
 
 ```js
 module.exports = handleErrors(async (req, res) => {

--- a/bin/micro
+++ b/bin/micro
@@ -75,6 +75,8 @@ if ('function' !== typeof mod) {
 
 if ('function' !== typeof onError) {
   onError = null
+} else {
+  console.warn('[DEPRECATED] onError is deprecated and will be removed in a future release. Please use your own try/catch as needed.')
 }
 
 const { port, host } = args

--- a/bin/micro
+++ b/bin/micro
@@ -55,11 +55,9 @@ if ('/' !== file[0]) {
 require('async-to-gen/register')
 
 let mod
-let onError
 
 try {
   mod = require(file);
-  onError = mod.onError
   if (mod && 'object' === typeof mod) {
     mod = mod.default;
   }
@@ -73,14 +71,8 @@ if ('function' !== typeof mod) {
   process.exit(1)
 }
 
-if ('function' !== typeof onError) {
-  onError = null
-} else {
-  console.warn('[DEPRECATED] onError is deprecated and will be removed in a future release. Please use your own try/catch as needed.')
-}
-
 const { port, host } = args
-serve(mod, { onError }).listen(port, host, err => {
+serve(mod).listen(port, host, err => {
   if (err) {
     console.error('micro:', err.stack)
     process.exit(1)

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,10 @@ exports.sendError = sendError
 exports.createError = createError
 
 function serve(fn, {onError = null} = {}) {
+  if (onError) {
+    console.warn('[DEPRECATED] onError is deprecated and will be removed in a future release. Please use your own try/catch as needed.')
+  }
+
   return server((req, res) => {
     run(req, res, fn, onError || sendError)
   })


### PR DESCRIPTION
As discussed, in #99 and #102, this adds a console warning message that `onError` is now deprecated.

We could also remove the additions from #99 as no one is probably using them yet? I personally am now using this: https://github.com/rickharrison/micro-json-error
