### PR TITLE
Added didBoot(port, host)

### DIFF
--- a/bin/micro
+++ b/bin/micro
@@ -60,11 +60,15 @@ if ('/' !== file[0]) {
 require('async-to-gen/register')
 
 let mod
+let didBoot = function () {
+	console.log(`> Ready! Listening on http://${host}:${port}`)
+}
 
 try {
   mod = require(file);
   if (mod && 'object' === typeof mod) {
-    mod = mod.default;
+	didBoot = mod.didBoot ? mod.didBoot : didBoot
+	mod = mod.default;
   }
 } catch (err) {
   console.error(`micro: Error when importing ${file}: ${err.stack}`)
@@ -82,5 +86,5 @@ serve(mod).listen(port, host, err => {
     console.error('micro:', err.stack)
     process.exit(1)
   }
-  console.log(`> Ready! Listening on http://${host}:${port}`)
+  didBoot(host, port)
 })


### PR DESCRIPTION
# Description
*fn:* didBoot (port, host)

micro now possesses a function called didBoot which will run after the server has booten up and can optionally be changed by the user when exporting a function with the same name.
By default it will just print the current known startup message. 

**Example**
`exports.didBoot = (port, host) => {
     // after boot
}`