### PR TITLE
Proposal: Add 'text' method for body parsing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ const DEV = 'development' === process.env.NODE_ENV
 module.exports = exports = serve
 
 exports.run = run
+exports.text = text
 exports.json = json
 exports.send = send
 exports.sendError = sendError
@@ -39,24 +40,27 @@ async function run(req, res, fn, onError) {
   }
 }
 
-async function json(req, {limit = '1mb'} = {}) {
+async function text(req, {limit = '1mb'} = {}) {
   try {
     const type = req.headers['content-type']
     const length = req.headers['content-length']
     const encoding = typer.parse(type).parameters.charset
-    const str = await getRawBody(req, {limit, length, encoding})
-
-    try {
-      return JSON.parse(str)
-    } catch (err) {
-      throw createError(400, 'Invalid JSON', err)
-    }
+    return await getRawBody(req, {limit, length, encoding})
   } catch (err) {
     if ('entity.too.large' === err.type) {
       throw createError(413, `Body exceeded ${limit} limit`, err)
     } else {
       throw createError(400, 'Invalid body', err)
     }
+  }
+}
+
+async function json(req, {limit = '1mb'} = {}) {
+  const str = text(req, {limit});
+  try {
+    return JSON.parse(str)
+  } catch (err) {
+    throw createError(400, 'Invalid JSON', err)
   }
 }
 


### PR DESCRIPTION
While using micro to build out a GraphQL endpoint, I immediately ran into the issue of needing to get the graphQL query from the request object. I could use `raw-body` to do this directly, but seeing as how the `json()` function already has all of this logic, it seemed like a reasonable extension of the micro API.

I also understand that keeping the API tiny and simple is a priority for the project, so if this doesn't fit your direction, that's 👍

The included diff is just a quick proposal of the change. If this looks good I'll flesh out the tests and docs.