### PR TITLE
Add method to parse plain text from request body

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,26 @@ $ npm start
   }
   ```
 
+#### text
+
+**`text(req, { limit = '1mb' })`**
+
+- Use `require('micro').text`.
+- Buffers and parses the incoming body and returns it as plain text.
+- Exposes an `async` function that can be run with  `await`.
+- `limit` is how much data is aggregated before parsing at max. Otherwise, an `Error` is thrown with `statusCode` set to `413` (see [Error Handling](#error-handling)). It can be a `Number` of bytes or [a string](https://www.npmjs.com/package/bytes) like `'1mb'`.
+- If String parsing fails, an `Error` is thrown with `statusCode` set to `400` (see [Error Handling](#error-handling))
+- Example:
+
+  ```js
+  const { json, send } = require('micro');
+  module.exports = async function (req, res) {
+    const str = await text(req);
+    console.log(str);
+    send(res, 200, {response: str});
+  }
+  ```
+
 #### send
 
 **`send(res, statusCode, data = null)`**

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@ module.exports = exports = serve
 
 exports.run = run
 exports.json = json
+exports.text = text
 exports.send = send
 exports.sendError = sendError
 exports.createError = createError
@@ -39,24 +40,38 @@ async function run(req, res, fn, onError) {
   }
 }
 
-async function json(req, {limit = '1mb'} = {}) {
+async function buffer(req, {limit = '1mb'} = {}) {
   try {
     const type = req.headers['content-type']
     const length = req.headers['content-length']
     const encoding = typer.parse(type).parameters.charset
-    const str = await getRawBody(req, {limit, length, encoding})
+    const buff = await getRawBody(req, {limit, length, encoding})
 
-    try {
-      return JSON.parse(str)
-    } catch (err) {
-      throw createError(400, 'Invalid JSON', err)
-    }
+    return buff
   } catch (err) {
     if ('entity.too.large' === err.type) {
       throw createError(413, `Body exceeded ${limit} limit`, err)
     } else {
       throw createError(400, 'Invalid body', err)
     }
+  }
+}
+
+async function json(req, options = {}) {
+  const str = await buffer(req, options)
+  try {
+    return JSON.parse(str)
+  } catch (err) {
+    throw createError(400, 'Invalid JSON', err)
+  }
+}
+
+async function text(req, options = {}) {
+  const str = await buffer(req, options)
+  try {
+    return str.toString()
+  } catch (err) {
+    throw createError(400, 'Invalid body', err)
   }
 }
 


### PR DESCRIPTION
This PR abstracts the logic to parse the raw buffer from a request so it can be used by `json` and also a new `text` method enabling parsing of plain text from request.