### PR TITLE
support PORT environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ To run the microservice on port `3000` and localhost instead of listening on eve
 $ micro -p 3000 -H localhost sleep.js
 ```
 
+`micro` also supports using the `PORT` environment variable to set the port:
+
+```bash
+$ PORT=3000 micro sleep.js
+```
+
 ## Usage
 
 **Note**: `micro` requires Node `6.0.0` or later

--- a/bin/micro
+++ b/bin/micro
@@ -19,7 +19,7 @@ const args = parse(process.argv, {
   boolean: ['h'],
   default: {
     H: '0.0.0.0',
-    p: 3000
+    p: process.env.PORT || 3000
   }
 })
 let [,, file] = args._;


### PR DESCRIPTION
This enables the use of a `PORT` environment variable that is commonly used with PaaS services such as Heroku and Cloud Foundry. Still defaults to `3000` if the env var is not set.