### PR TITLE
Don't log errors when testing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -114,7 +114,9 @@ function sendError(req, res, {statusCode, message, stack}) {
     send(res, 500, DEV ? stack : 'Internal Server Error')
   }
 
-  if (!TESTING) console.error(stack)
+  if (!TESTING) {
+    console.error(stack)
+  }
 }
 
 function createError(code, msg, orig) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ const typer = require('media-typer')
 const isStream = require('isstream')
 
 const DEV = 'development' === process.env.NODE_ENV
+const TESTING = 'test' === process.env.NODE_ENV
 
 module.exports = exports = serve
 
@@ -113,7 +114,7 @@ function sendError(req, res, {statusCode, message, stack}) {
     send(res, 500, DEV ? stack : 'Internal Server Error')
   }
 
-  console.error(stack)
+  if (!TESTING) console.error(stack)
 }
 
 function createError(code, msg, orig) {


### PR DESCRIPTION
Jest, the test runner, catches all console logs that happen during tests and outputs them at the end

I want to test that an error is thrown at a certain point in time, but because `micro` automatically `console.error`s errors it looks like the test failed, even though it didn't:

![screen shot 2017-01-09 at 17 48 31](https://cloud.githubusercontent.com/assets/7525670/21774801/fcb9bb04-d693-11e6-8480-06c0e806add7.png)

See that red stack trace? It's totally unnecessary and doesn't have to be there, as the test passed and this is expected behaviour.

> **Note:** This might be the wrong solution for the problem, throwing this PR out to kick off a discussion.