### PR TITLE
Add sourcemap support

### DIFF
--- a/bin/micro
+++ b/bin/micro
@@ -10,6 +10,8 @@ const isAsyncSupported = require('is-async-supported')
 // Ours
 const serve = require('../')
 
+const DEV = 'development' === process.env.NODE_ENV
+
 const args = parse(process.argv, {
   alias: {
     H: 'host',
@@ -59,7 +61,7 @@ if ('/' !== file[0]) {
 }
 
 if (!isAsyncSupported()) {
-  require('async-to-gen/register')
+  require('async-to-gen/register')({ sourceMaps: DEV })
 }
 
 let mod


### PR DESCRIPTION
Tested in vscode's debug mode (which is excellent btw) with this configuration:

```cson
{
    // Use IntelliSense to learn about possible Node.js debug attributes.
    // Hover to view descriptions of existing attributes.
    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
    "version": "0.2.0",
    "configurations": [
        {
            "type": "node2",
            "request": "launch",
            "name": "Launch Program",
            "program": "${workspaceRoot}/node_modules/micro/bin/micro",
            "cwd": "${workspaceRoot}",
            "args": ["."],
            "sourceMaps": true,
            "env": {
                "NODE_ENV": "development"
            }
        },
        {
            "type": "node2",
            "request": "attach",
            "name": "Attach to Process",
            "port": 5858
        }
    ]
}
```