### PR TITLE
Allow ``json`` to be called multiple times

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ npm start
 - Use `require('micro').json`.
 - Buffers and parses the incoming body and returns it.
 - Exposes an `async` function that can be run with  `await`.
+- Can be called multiple times, as it caches the raw request body the first time.
 - `limit` is how much data is aggregated before parsing at max. Otherwise, an `Error` is thrown with `statusCode` set to `413` (see [Error Handling](#error-handling)). It can be a `Number` of bytes or [a string](https://www.npmjs.com/package/bytes) like `'1mb'`.
 - If JSON parsing fails, an `Error` is thrown with `statusCode` set to `400` (see [Error Handling](#error-handling))
 - Example:

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,17 +40,20 @@ async function run(req, res, fn, onError) {
   }
 }
 
-const requestMap = new WeakMap()
+// maps requests to buffered raw bodies so that
+// multiple calls to `json` work as expected
+const rawBodyMap = new WeakMap()
+
 async function json(req, {limit = '1mb'} = {}) {
   try {
     const type = req.headers['content-type']
     const length = req.headers['content-length']
     const encoding = typer.parse(type).parameters.charset
 
-    let str = requestMap.get(req)
+    let str = rawBodyMap.get(req)
     if (!str) {
       str = getRawBody(req, {limit, length, encoding})
-      requestMap.set(req, str)
+      rawBodyMap.set(req, str)
     }
 
     try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,14 +40,18 @@ async function run(req, res, fn, onError) {
   }
 }
 
+const requestMap = new WeakMap()
 async function json(req, {limit = '1mb'} = {}) {
   try {
     const type = req.headers['content-type']
     const length = req.headers['content-length']
     const encoding = typer.parse(type).parameters.charset
 
-    req.rawBody = req.rawBody || getRawBody(req, {limit, length, encoding})
-    const str = await req.rawBody
+    let str = requestMap.get(req)
+    if (!str) {
+      str = getRawBody(req, {limit, length, encoding})
+      requestMap.set(req, str)
+    }
 
     try {
       return JSON.parse(str)

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ async function json(req, {limit = '1mb'} = {}) {
     const type = req.headers['content-type']
     const length = req.headers['content-length']
     const encoding = typer.parse(type).parameters.charset
-    
+
     req.rawBody = req.rawBody || getRawBody(req, {limit, length, encoding})
     const str = await req.rawBody
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,9 @@ async function json(req, {limit = '1mb'} = {}) {
     const type = req.headers['content-type']
     const length = req.headers['content-length']
     const encoding = typer.parse(type).parameters.charset
-    const str = await getRawBody(req, {limit, length, encoding})
+    
+    req.rawBody = req.rawBody || getRawBody(req, {limit, length, encoding})
+    const str = await req.rawBody
 
     try {
       return JSON.parse(str)

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,7 +52,7 @@ async function json(req, {limit = '1mb'} = {}) {
 
     let str = rawBodyMap.get(req)
     if (!str) {
-      str = getRawBody(req, {limit, length, encoding})
+      str = await getRawBody(req, {limit, length, encoding})
       rawBodyMap.set(req, str)
     }
 


### PR DESCRIPTION
Consider a wrapper function that calls the ``json`` function, while wrapping another function that calls the ``json`` function as well, e.g.

```js
const { json } = require('micro')

const wrapper = function (fn) {
  return async function (req, res) {
    console.log('wrapper', await json(req))
    return await fn(req, res)
  }
}

module.exports = wrapper(async function (req, res) {
  console.log('main', await json(req))
  return 'stuff'
})
```

The call to ``json`` by the wrapper would block the next call indefinitely, since the stream from ``req`` has already been read.

This PR solves that.