### PR TITLE
Remove greenkeeper email option

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
     "dist",
     "bin"
   ],
-  "greenkeeper": {
-    "emails": false
-  },
   "scripts": {
     "prepublish": "npm run build",
     "pretest": "npm run build",


### PR DESCRIPTION
Saw it was removed from serve because it didn't do anything. Therefor removed here.