### PR TITLE
Include lib and bin into async-to-gen compilation

### DIFF
--- a/bin/micro.js
+++ b/bin/micro.js
@@ -60,7 +60,7 @@ if (!isAsyncSupported()) {
   const directoryName = path.parse(path.join(__dirname, '..')).base
 
   asyncToGen({
-    includes: new RegExp(`.*${directoryName}?${pathSep}(lib|bin)|${file}.*`),
+    includes: new RegExp(`.*(${directoryName})?${pathSep}(lib|bin)|${file}.*`),
     excludes: null,
     sourceMaps: false
   })


### PR DESCRIPTION
It seems the current regex rejects `./lib` and `./bin`. But allow `micr/lib` and `micr/bin` instead.