### PR TITLE
Fix transpilation on Windows platform

### DIFF
--- a/bin/micro.js
+++ b/bin/micro.js
@@ -58,7 +58,9 @@ if (!isAsyncSupported()) {
   // Support for keywords "async" and "await"
   const pathSep = process.platform === 'win32' ? '\\\\' : '/'
   const directoryName = path.parse(path.join(__dirname, '..')).base
-  const fileDirectoryPath = path.parse(file).dir
+  let fileDirectoryPath = path.parse(file).dir
+
+  fileDirectoryPath = fileDirectoryPath.split(path.sep).join(pathSep)
 
   asyncToGen({
     includes: new RegExp(`.*${directoryName}?${pathSep}(lib|bin)|${fileDirectoryPath}.*`),


### PR DESCRIPTION
This change fix the issue #145, where the code was not transpiled on Windows platform.

The issue was a escaping issue with the `\` directory separator of windows in the regex that check if the file exists or not.