### PR TITLE
lazy load async-to-gen/register

### DIFF
--- a/bin/micro.js
+++ b/bin/micro.js
@@ -4,7 +4,6 @@
 const path = require('path')
 
 // Packages
-const asyncToGen = require('async-to-gen/register')
 const updateNotifier = require('update-notifier')
 const nodeVersion = require('node-version')
 const args = require('args')
@@ -55,6 +54,7 @@ if (file[0] !== '/') {
 }
 
 if (!isAsyncSupported()) {
+  const asyncToGen = require('async-to-gen/register')
   // Support for keywords "async" and "await"
   const pathSep = process.platform === 'win32' ? '\\\\' : '/'
   const directoryName = path.parse(path.join(__dirname, '..')).base


### PR DESCRIPTION
nodejs v7.6.0 had been released with V8 5.5, hence native async/await support. i would suggest to not lazy load async-to-gen/register

Benchmarks:
* node@7.5.0 x micro@master: 0.26s
* node@7.6.0 x micro@master: 0.26s
* node@7.5.0 x micro@feat/optim-start: 0.26s
* node@7.6.0 x micro@feat/optim-start: 0.19s

TLDR: 19.2% faster start up time for envs with async/await support (nodejs 7.6+ && nodejs 8+)