### PR TITLE
Remove bluebird.coroutine

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -5,6 +5,9 @@ const server = require('http').Server
 const getRawBody = require('raw-body')
 const typer = require('media-typer')
 const isStream = require('isstream')
+const Promise = require('bluebird')
+
+const {resolve} = Promise
 
 const DEV = process.env.NODE_ENV === 'development'
 const TESTING = process.env.NODE_ENV === 'test'
@@ -18,7 +21,7 @@ exports.sendError = sendError
 exports.createError = createError
 
 exports.run = (req, res, fn) =>
-  Promise.resolve(fn(req, res))
+  resolve(fn(req, res))
     .then(val => {
       if (val === null) {
         send(res, 204, null)

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,16 +5,11 @@ const server = require('http').Server
 const getRawBody = require('raw-body')
 const typer = require('media-typer')
 const isStream = require('isstream')
-const Promise = require('bluebird')
-
-const {coroutine, resolve} = Promise
 
 const DEV = process.env.NODE_ENV === 'development'
 const TESTING = process.env.NODE_ENV === 'test'
 
-const serve = fn => server(coroutine(function * (req, res) {
-  yield exports.run(req, res, fn)
-}))
+const serve = fn => server((req, res) => exports.run(req, res, fn))
 
 module.exports = exports = serve
 
@@ -22,22 +17,19 @@ exports.send = send
 exports.sendError = sendError
 exports.createError = createError
 
-exports.run = coroutine(function * (req, res, fn) {
-  try {
-    const val = yield resolve(fn(req, res))
+exports.run = (req, res, fn) =>
+  Promise.resolve(fn(req, res))
+    .then(val => {
+      if (val === null) {
+        send(res, 204, null)
+      }
 
-    if (val === null) {
-      send(res, 204, null)
-    }
-
-    // Return a undefined-null value -> send
-    if (undefined !== val) {
-      send(res, res.statusCode || 200, val)
-    }
-  } catch (err) {
-    sendError(req, res, err)
-  }
-})
+      // Return a undefined-null value -> send
+      if (undefined !== val) {
+        send(res, res.statusCode || 200, val)
+      }
+    })
+    .catch(err => sendError(req, res, err))
 
 // maps requests to buffered raw bodies so that
 // multiple calls to `json` work as expected

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "dependencies": {
     "args": "2.3.0",
     "async-to-gen": "1.3.2",
+    "bluebird": "3.4.7",
     "boxen": "1.0.0",
     "chalk": "1.1.3",
     "copy-paste": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   "dependencies": {
     "args": "2.3.0",
     "async-to-gen": "1.3.2",
-    "bluebird": "^3.4.7",
     "boxen": "1.0.0",
     "chalk": "1.1.3",
     "copy-paste": "1.3.0",


### PR DESCRIPTION
~~Since Node.JS 7.6.0 supports `async`/`await` without flags.~~

Coroutine is used just for couple `yields` in code and can be safely replaced with Promise chain.

Benchmark results (based on [`polkadot`](https://github.com/lukeed/polkadot/tree/master/benchmarks) benchmarks). 

Commands for benchmarking:

- **wrk**: `wrk -t12 -c400 -d30s http://localhost:3000/`
- **ab**: `ab -c4 -n5000 http://0.0.0.0:3000/`

And numbers:

&nbsp; | Node 7.5.0 (wrk) | Node 7.5.0 (ab) | Node 7.6.0 (wrk) | Node 7.6.0 (ab)
------- | ---------- | ------------- | ------------ | -------------
7.0.6 | 6553.51 | 1990.89  | 7854.89  | 2609.53 
master | 12353.73 | 3036.74  | 15519.98  | 4412.05 
PR | 14492.10 | 3698.73 | 17533.89 | 5631.77

On `7.5.0` app was launched with `micro`, on `7.6.0` app was launched with `node`.

Performance can be doubled with [uWebSockets](https://github.com/uWebSockets/uWebSockets) (up to 31843 rps).