### PR TITLE
Add `status` fallback to error handling

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -126,9 +126,9 @@ function send(res, code, obj = null) {
   res.end(str)
 }
 
-function sendError(req, res, {statusCode, message, stack}) {
+function sendError(req, res, {statusCode, status, message, stack}) {
   if (statusCode) {
-    send(res, statusCode, DEV ? stack : message)
+    send(res, statusCode || status, DEV ? stack : message)
   } else {
     send(res, 500, DEV ? stack : 'Internal Server Error')
   }


### PR DESCRIPTION
Add `status` fallback to error handling.
This change makes some useful libraries(http-assert) compatible with `micro` 🚀