### PR TITLE
Allow numbers as responses.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -101,7 +101,7 @@ function send(res, code, obj = null) {
 
   let str = obj
 
-  if (typeof obj === 'object') {
+  if (typeof obj === 'object' || typeof obj === 'number') {
     // we stringify before setting the header
     // in case `JSON.stringify` throws and a
     // 500 has to be sent instead

--- a/test/index.js
+++ b/test/index.js
@@ -43,6 +43,20 @@ test('send(200, <Object>)', async t => {
   })
 })
 
+test('send(200, <Number>)', async t => {
+  const fn = async (req, res) => {
+    // chosen by fair dice roll. guaranteed to be random.
+    send(res, 200, 4)
+  }
+
+  const url = await getUrl(fn)
+  const res = await request(url, {
+    json: true
+  })
+
+  t.deepEqual(res, 4)
+})
+
 test('send(200, <Buffer>)', async t => {
   const fn = async (req, res) => {
     send(res, 200, new Buffer('muscle'))
@@ -135,6 +149,20 @@ test('return <Object>', async t => {
   t.deepEqual(res, {
     a: 'b'
   })
+})
+
+test('return <Number>', async t => {
+  const fn = async () => {
+    // chosen by fair dice roll. guaranteed to be random.
+    return 4
+  }
+
+  const url = await getUrl(fn)
+  const res = await request(url, {
+    json: true
+  })
+
+  t.deepEqual(res, 4)
 })
 
 test('return <Buffer>', async t => {


### PR DESCRIPTION
I was trying to write a microservice earlier today and came to realize that you can't return numbers from your handlers. Plain numbers are actually valid JSON, so I think it makes sense to support them.

Might I also suggest linting _after_ running tests? Sometimes it would be nice to run `npm test` and get some actual test output without having to worry about style problems which can be fixed later.