### PR TITLE
Remove redundant async/await in server.listen

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,12 +28,12 @@ module.exports = async (file, flags, module = getModule(file)) => {
     host = null
   }
 
-  server.listen(port, host, async err => {
+  server.listen(port, host, err => {
     if (err) {
       console.error('micro:', err.stack)
       process.exit(1)
     }
 
-    return await listening(server, inUse)
+    return listening(server, inUse)
   })
 }


### PR DESCRIPTION
Since there is no awaits in the middle, callback can just return Promise directly.