### PR TITLE
Simplify returnJSON function

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -5,9 +5,7 @@ const server = require('http').Server
 const getRawBody = require('raw-body')
 const typer = require('media-typer')
 const isStream = require('isstream')
-const Promise = require('bluebird')
-
-const {resolve} = Promise
+const {resolve} = require('bluebird')
 
 const DEV = process.env.NODE_ENV === 'development'
 const TESTING = process.env.NODE_ENV === 'test'
@@ -38,15 +36,15 @@ exports.run = (req, res, fn) =>
 // multiple calls to `json` work as expected
 const rawBodyMap = new WeakMap()
 
-const returnJSON = (resolve, reject, str) => {
+const parseJSON = str => {
   try {
-    resolve(JSON.parse(str))
+    return JSON.parse(str)
   } catch (err) {
-    reject(createError(400, 'Invalid JSON', err))
+    throw createError(400, 'Invalid JSON', err)
   }
 }
 
-exports.json = (req, {limit = '1mb'} = {}) => new Promise((resolve, reject) => {
+exports.json = (req, {limit = '1mb'} = {}) => resolve().then(() => {
   const type = req.headers['content-type']
   const length = req.headers['content-length']
   const encoding = typer.parse(type).parameters.charset
@@ -54,15 +52,14 @@ exports.json = (req, {limit = '1mb'} = {}) => new Promise((resolve, reject) => {
   let str = rawBodyMap.get(req)
 
   if (str) {
-    returnJSON(resolve, reject, str)
-    return
+    return parseJSON(str)
   }
 
-  getRawBody(req, {limit, length, encoding}).then(buf => {
+  return getRawBody(req, {limit, length, encoding}).then(buf => {
     str = buf
     rawBodyMap.set(req, str)
 
-    returnJSON(resolve, reject, str)
+    return parseJSON(str)
   }).catch(err => {
     if (err.type === 'entity.too.large') {
       throw createError(413, `Body exceeded ${limit} limit`, err)


### PR DESCRIPTION
Passing `resolve` and `reject` around can become messy and can make transition to `async`/`await` harder.