### PR TITLE
Null value from fn should cause one res.end call

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -23,11 +23,13 @@ exports.run = (req, res, fn) =>
     .then(val => {
       if (val === null) {
         send(res, 204, null)
+        return
       }
 
       // Return a undefined-null value -> send
       if (undefined !== val) {
         send(res, res.statusCode || 200, val)
+        return
       }
     })
     .catch(err => sendError(req, res, err))

--- a/test/index.js
+++ b/test/index.js
@@ -183,6 +183,25 @@ test('return <Stream>', async t => {
   t.deepEqual(res, 'River')
 })
 
+test('return <null>', async t => {
+  const fn = async () => null
+
+  const url = await getUrl(fn)
+  const res = await request(url, {resolveWithFullResponse: true})
+
+  t.is(res.statusCode, 204)
+  t.is(res.body, '')
+})
+
+test('return <null> calls res.end once', async t => {
+  const fn = async () => null
+
+  let i = 0
+  await micro.run({}, {end: () => i++}, fn)
+
+  t.is(i, 1)
+})
+
 test('throw with code', async t => {
   const fn = async () => {
     await sleep(100)


### PR DESCRIPTION
Small bug 🐛 

I wonder, why node is not panic on this situation. 