### PR TITLE
Undefined from fn should not hang request

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -21,16 +21,12 @@ exports.createError = createError
 exports.run = (req, res, fn) =>
   resolve(fn(req, res))
     .then(val => {
-      if (val === null) {
+      if (val === null || val === undefined) {
         send(res, 204, null)
         return
       }
 
-      // Return a undefined-null value -> send
-      if (undefined !== val) {
-        send(res, res.statusCode || 200, val)
-        return
-      }
+      send(res, res.statusCode || 200, val)
     })
     .catch(err => sendError(req, res, err))
 

--- a/test/index.js
+++ b/test/index.js
@@ -202,6 +202,16 @@ test('return <null> calls res.end once', async t => {
   t.is(i, 1)
 })
 
+test('return <undefined>', async t => {
+  const fn = async () => {}
+
+  const url = await getUrl(fn)
+  const res = await request(url, {resolveWithFullResponse: true})
+
+  t.is(res.statusCode, 204)
+  t.is(res.body, '')
+})
+
 test('throw with code', async t => {
   const fn = async () => {
     await sleep(100)


### PR DESCRIPTION
Not-quite-small bug 🐞 

I'm not sure, this is the right way to deal with `undefined` from `fn`, but surely one of. Other way – to throw error.