### PR TITLE
Fix for #164 – status should not be ignored

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -119,8 +119,10 @@ function send(res, code, obj = null) {
 }
 
 function sendError(req, res, {statusCode, status, message, stack}) {
+  statusCode = statusCode || status
+
   if (statusCode) {
-    send(res, statusCode || status, DEV ? stack : message)
+    send(res, statusCode, DEV ? stack : message)
   } else {
     send(res, 500, DEV ? stack : 'Internal Server Error')
   }

--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,7 @@ const resumer = require('resumer')
 const listen = require('test-listen')
 const micro = require('../lib/server')
 
-const {send, json} = micro
+const {send, sendError, json} = micro
 
 const getUrl = fn => {
   const srv = micro(fn)
@@ -418,4 +418,19 @@ test('limit included in error', async t => {
   }
 
   await getUrl(fn)
+})
+
+test('support for status fallback in errors', async t => {
+  const fn = (req, res) => {
+    const err = new Error('Custom')
+    err.status = 403
+    sendError(req, res, err)
+  }
+
+  const url = await getUrl(fn)
+  try {
+    await request(url)
+  } catch (err) {
+    t.deepEqual(err.statusCode, 403)
+  }
 })


### PR DESCRIPTION
Fallback `statusCode || status` was under `if (statusCode) { ... }` – so it never worked (because `statusCode` is always truthy.