### PR TITLE
Add coveralls.io badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,8 @@
   "node_js": [
     "6",
     "node"
+  ],
+  "after_success": [
+    "./node_modules/.bin/nyc report --reporter=text-lcov | ./node_modules/.bin/coveralls"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "homepage": "https://github.com/zeit/micro#readme",
   "devDependencies": {
     "ava": "0.18.2",
+    "coveralls": "2.12.0",
     "husky": "0.13.3-0",
     "nyc": "10.1.2",
     "request": "2.81.0",

--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,7 @@
 _**Micro —** Async ES6 HTTP microservices_
 
 [![Build Status](https://travis-ci.org/zeit/micro.svg?branch=master)](https://travis-ci.org/zeit/micro)
+[![Coverage Status](https://coveralls.io/repos/github/zeit/micro/badge.svg?branch=master)](https://coveralls.io/github/zeit/micro?branch=master)
 [![Slack Channel](https://zeit-slackin.now.sh/badge.svg)](https://zeit.chat/)
 [![XO code style](https://img.shields.io/badge/code_style-XO-5ed9c7.svg)](https://github.com/sindresorhus/xo)
 


### PR DESCRIPTION
This repository should be activated on [coveralls.io](https://coveralls.io/repos/new) first (would be sweet also show coverage change on PR's).

Closes #182