### PR TITLE
Support HEAD method

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -18,8 +18,10 @@ exports.send = send
 exports.sendError = sendError
 exports.createError = createError
 
-exports.run = (req, res, fn) =>
-  new Promise(resolve => resolve(fn(req, res)))
+exports.run = (req, res, fn) => {
+  res.request = req
+
+  return new Promise(resolve => resolve(fn(req, res)))
     .then(val => {
       if (val === null || val === undefined) {
         send(res, 204, null)
@@ -29,6 +31,7 @@ exports.run = (req, res, fn) =>
       send(res, res.statusCode || 200, val)
     })
     .catch(err => sendError(req, res, err))
+}
 
 // maps requests to buffered raw bodies so that
 // multiple calls to `json` work as expected
@@ -69,6 +72,10 @@ exports.json = (req, {limit = '1mb'} = {}) => Promise.resolve().then(() => {
 
 function send(res, code, obj = null) {
   res.statusCode = code
+
+  if (res.request && res.request.method === 'HEAD') {
+    obj = null
+  }
 
   if (obj === null) {
     res.end()

--- a/test/index.js
+++ b/test/index.js
@@ -477,3 +477,48 @@ test('support for status fallback in errors', async t => {
     t.deepEqual(err.statusCode, 403)
   }
 })
+
+test('head method should not send response', async t => {
+  const fn = () => 'Hello'
+
+  const url = await getUrl(fn)
+
+  const res = await request(url, {
+    method: 'HEAD',
+    resolveWithFullResponse: true
+  })
+
+  t.is(res.body, '')
+})
+
+test('head method should not send error message', async t => {
+  const fn = async () => {
+    throw new Error('Bang')
+  }
+
+  const url = await getUrl(fn)
+
+  try {
+    await request(url, {
+      method: 'HEAD',
+      resolveWithFullResponse: true
+    })
+  } catch (err) {
+    t.is(err.statusCode, 500)
+    t.is(err.response.body, '')
+  }
+})
+
+test('send(200, <String>) with HEAD request', async t => {
+  const fn = async (req, res) => {
+    send(res, 200, 'woot')
+  }
+
+  const url = await getUrl(fn)
+  const res = await request(url, {
+    method: 'HEAD',
+    resolveWithFullResponse: true
+  })
+
+  t.is(res.body, '')
+})


### PR DESCRIPTION
This is one way to solve `HEAD` requests. I don't like fiddling with `err.mesage`, but I don't like idea to pass `req` into `send` method.

Closes #184 