### PR TITLE
Use text/plain as default content-type in .json

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -49,7 +49,7 @@ const parseJSON = str => {
 
 exports.json = (req, { limit = '1mb' } = {}) =>
   Promise.resolve().then(() => {
-    const type = req.headers['content-type'];
+    const type = req.headers['content-type'] || 'text/plain';
     const length = req.headers['content-length'];
     const encoding = typer.parse(type).parameters.charset;
 

--- a/test/index.js
+++ b/test/index.js
@@ -586,3 +586,16 @@ test('res.end is working', async t => {
 
   t.deepEqual(res, 'woot');
 });
+
+test('json should throw 400 on empty body with no headers', async t => {
+  const fn = async req => json(req);
+
+  const url = await getUrl(fn);
+
+  try {
+    await request(url);
+  } catch (err) {
+    t.is(err.message, '400 - "Invalid body"');
+    t.is(err.statusCode, 400);
+  }
+});


### PR DESCRIPTION
Otherwise `media-typer` throws an error:

```
TypeError: argument string is required
    at Object.parse (/Users/floatdrop/github.com/micro/examples/json-body-parsing/node_modules/media-typer/index.js:141:11)
    at Promise.resolve.then (/Users/floatdrop/github.com/micro/examples/json-body-parsing/node_modules/micro/lib/server.js:52:26)
```