### PR TITLE
Fix server.listen error handling

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,14 +28,14 @@ module.exports = async (file, flags, module = getModule(file)) => {
     host = null;
   }
 
-  server.listen(port, host, err => {
-    if (err) {
-      console.error('micro:', err.stack);
+  server.on('error', err => {
+    console.error('micro:', err.stack);
 
-      // eslint-disable-next-line unicorn/no-process-exit
-      process.exit(1);
-    }
+    // eslint-disable-next-line unicorn/no-process-exit
+    process.exit(1);
+  });
 
+  server.listen(port, host, () => {
     return listening(server, inUse, flags.silent);
   });
 };


### PR DESCRIPTION
In the current implementation error handler for server.listen can never be called.

Part of `http` documentation concerns `callback` attribute for `listen` method:
> This function is asynchronous. callback will be added as a listener for the **'listening'** event. 

So we need to catch errors through 'error' event listener.