### PR TITLE
Added HTTPS example

### DIFF
--- a/examples/with-https/index.js
+++ b/examples/with-https/index.js
@@ -1,0 +1,21 @@
+const https = require('https')
+const { run, send } = require('micro')
+
+const cert = require('openssl-self-signed-certificate')
+
+const PORT = process.env.PORT || 3443
+
+const options = {
+  key: cert.key,
+  cert: cert.cert,
+  passphrase: cert.passphrase
+}
+
+const microHttps = fn => https.createServer(options, (req, res) => run(req, res, fn))
+
+const server = microHttps(async (req, res) => {
+  send(res, 200, { encrypted: req.client.encrypted })
+})
+
+server.listen(PORT)
+console.log(`Listening on https://localhost:${PORT}`)

--- a/examples/with-https/package.json
+++ b/examples/with-https/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "with-https",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "start": "node ."
+  },
+  "dependencies": {
+    "micro": "latest",
+    "openssl-self-signed-certificate": "^1.1.6"
+  }
+}


### PR DESCRIPTION
Just had a look at the source, and it's actually really easy to enable https! 🎉 

Since we want to keep micro **micro** I think the cli version of this should be published as a plugin to micro or as a separate cli that uses micro under the hood `micro-https`, thoughts?

That could use `ssl-self-signed-certificate` or similar to provision easy ssl for localhost/hosts-file domains when developing.

https://github.com/zeit/micro/issues/224

I'll publish this as a module so it can be used in zeit/serve if you want 🙌 