### PR TITLE
Drain current requests before exit

### DIFF
--- a/lib/listening.js
+++ b/lib/listening.js
@@ -21,8 +21,7 @@ module.exports = async (server, inUse, silent) => {
   const isTTY = process.stdout.isTTY
 
   process.on('SIGINT', () => {
-    server.close()
-    process.exit(0)
+    server.close(() => process.exit(0))
   })
 
   if (!(silent || process.env.NOW)) {


### PR DESCRIPTION
The close call never gets a chance to finish up awaiting requests before node exits, so those are dropped on the floor.
