### PR TITLE
Don't recommend installing async-to-gen globally

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ The package takes advantage of native support for `async` and `await`, which is 
 In order to do that, you firstly need to install it:
 
 ```bash
-npm install -g async-to-gen
+npm install --save async-to-gen
 ```
 
 And then add the transpilation command to the `scripts.build` property inside `package.json`:


### PR DESCRIPTION
It should be installed locally to the project so the build command works for other people checking out the project from git.