### PR TITLE
Replace media-typer module with content-type

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,8 +3,8 @@ const server = require('http').Server
 const { Stream } = require('stream')
 
 // Packages
+const contentType = require('content-type')
 const getRawBody = require('raw-body')
-const typer = require('media-typer')
 const { readable } = require('is-stream')
 
 const { NODE_ENV } = process.env
@@ -122,7 +122,7 @@ exports.buffer = (req, { limit = '1mb', encoding } = {}) =>
     const length = req.headers['content-length']
 
     if (encoding === undefined) {
-      encoding = typer.parse(type).parameters.charset
+      encoding = contentType.parse(type).parameters.charset
     }
 
     const body = rawBodyMap.get(req)

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "xo": "0.18.2"
   },
   "dependencies": {
+    "content-type": "1.0.4",
     "is-stream": "1.1.0",
-    "media-typer": "0.3.0",
     "mri": "1.1.0",
     "raw-body": "2.3.2"
   }


### PR DESCRIPTION
So this PR replaces the `media-typer` module with the `content-type` module. Both of these modules are part of the `jshttp` organization, and were doing similar things. This caused us to re-evaluate what exactly their roles were and so the `content-type` module is the one that parses the Content-Type HTTP header, which is what you are using it for. It works just like the version of `media-typer` you are currently using. The `media-typer` module will be releasing a new major that parses different strings, and so figured I'd help you move your framework now 👍 