### PR TITLE
Add port type and range validation to micro.

### DIFF
--- a/bin/micro.js
+++ b/bin/micro.js
@@ -82,6 +82,15 @@ if (!existsSync(file)) {
   process.exit(1)
 }
 
+const { port, host } = flags
+if (isNaN(port) || (!isNaN(port) && (port < 1 || port >= 2 ** 16))) {
+  logError(
+    `Port option must be a number. Supplied: ${port}`,
+    'invalid-server-port'
+  )
+  process.exit(1)
+}
+
 const loadedModule = handle(file)
 const server = serve(loadedModule)
 
@@ -90,7 +99,7 @@ server.on('error', err => {
   process.exit(1)
 })
 
-server.listen(flags.port, flags.host, () => {
+server.listen(port, host, () => {
   const details = server.address()
 
   process.on('SIGTERM', () => {

--- a/errors/invalid-server-port.md
+++ b/errors/invalid-server-port.md
@@ -1,0 +1,13 @@
+# Invalid Server Port
+
+#### Why This Error Occurred
+
+When the `micro` command was ran, you supplied the port flag although it is
+not a valid number.
+
+
+#### Possible Ways to Fix It
+
+The port must be a valid number between 1 and 65535. Although, remember some are
+reserved to the operating system and others not in userland (only accessible
+with administrator access).


### PR DESCRIPTION
Assuming that unix sockets are not supported since the message identifies them as `undefined`.
I'll gladly patch [micro-dev](https://github.com/zeit/micro-dev) with the same, if the change makes sense.