### PR TITLE
Replace exponential operator with Math.pow as it causes errors

### DIFF
--- a/bin/micro.js
+++ b/bin/micro.js
@@ -84,7 +84,7 @@ if (!existsSync(file)) {
 
 const { isNaN } = Number
 const port = Number(flags.port)
-if (isNaN(port) || (!isNaN(port) && (port < 1 || port >= 2 ** 16))) {
+if (isNaN(port) || (!isNaN(port) && (port < 1 || port >= Math.pow(2, 16)))) {
   logError(
     `Port option must be a number. Supplied: ${flags.port}`,
     'invalid-server-port'


### PR DESCRIPTION
Becouse after `npm start` it throws:
```
2 ** 16

SyntaxError: Unexpected token *
    at createScript (vm.js:56:10)
    at Object.runInThisContext (vm.js:97:10)
    at Module._compile (module.js:542:28)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
    at run (bootstrap_node.js:383:7)
    at startup (bootstrap_node.js:149:9)

```
would be better to switch it to `Math.pow`