### PR TITLE
[WIP] feat: support es6 module default export

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -9,7 +9,7 @@ module.exports = async file => {
     mod = await require(file) // Await to support exporting Promises
 
     if (mod && typeof mod === 'object') {
-      mod = mod.default
+      mod = await mod.default // Await to support es6 module's default export
     }
   } catch (err) {
     logError(`Error when importing ${file}: ${err.stack}`, 'invalid-entry')


### PR DESCRIPTION
this allows projects that compiled through babel can conveniently `export default` a Promise

```js
// instead of
module.exports = app.prepare().then(() => service);

// babel users can do this
export default app.prepare().then(() => service);
```