### PR TITLE
Splat listen() args to only specify host when supplied

### DIFF
--- a/bin/micro.js
+++ b/bin/micro.js
@@ -17,7 +17,6 @@ const logError = require('../lib/error')
 // Check if the user defined any options
 const flags = parseArgs(process.argv.slice(2), {
   default: {
-    host: '::',
     port: 3000
   },
   alias: {
@@ -101,7 +100,12 @@ async function start() {
     process.exit(1)
   })
 
-  server.listen(flags.port, flags.host, () => {
+  const listenArgs = [flags.port || 0]
+  if (flags.host) {
+    listenArgs.push(flags.host)
+  }
+
+  server.listen(...listenArgs, () => {
     const details = server.address()
 
     process.on('SIGTERM', () => {


### PR DESCRIPTION
This more strictly abides by the contract that a non-specified host in the `listen()` call might behave differently if the system is running IPv4 vs IPv6 as per the documentation (since the documentation doesn't specify _exactly_ what happens on an IPv4 system with `'::'`).