### PR TITLE
Avoid printing errors in test

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -83,6 +83,7 @@ const sendError = (req, res, errorObj) => {
   send(res, statusCode || 500, DEV ? errorObj.stack : message)
 
   // Avoid printing errors to the console when testing.
+  // istanbul ignore if
   if (process.env.NODE_ENV === 'test') {
     return
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -81,6 +81,12 @@ const sendError = (req, res, errorObj) => {
   const statusCode = errorObj.statusCode || errorObj.status
   const message = statusCode ? errorObj.message : 'Internal Server Error'
   send(res, statusCode || 500, DEV ? errorObj.stack : message)
+
+  // Avoid printing errors to the console when testing.
+  if (process.env.NODE_ENV === 'test') {
+    return
+  }
+
   if (errorObj instanceof Error) {
     console.error(errorObj.stack)
   } else {


### PR DESCRIPTION
This patch prevents us from logging errors when testing (assumes NODE_ENV is set to "test" when testing).

Closes #329.