### PR TITLE
Add badge to display install size

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,7 @@
 _**Micro** — Asynchronous HTTP microservices_
 
 [![CircleCI](https://circleci.com/gh/zeit/micro/tree/master.svg?style=shield)](https://circleci.com/gh/zeit/micro/tree/master)
+[![Install Size](https://packagephobia.now.sh/badge?p=micro)](https://packagephobia.now.sh/result?p=micro)
 [![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/micro)
 
 ## Features


### PR DESCRIPTION
This adds a badge to the `README.md` file to display the npm install size and show the world how tiny (and awesome) `micro` is 👍 

Related to #234