### PR TITLE
Automatically set Content-Length 0 if 204 status

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,6 +29,10 @@ const send = (res, code, obj = null) => {
 	res.statusCode = code;
 
 	if (obj === null) {
+		if (code === 204 && typeof res.setHeader === 'function') {
+			// Safari needs content-length 0 for 204 or it just hangs waiting for a body
+			res.setHeader('Content-Length', '0');
+		}
 		res.end();
 		return;
 	}

--- a/test/index.js
+++ b/test/index.js
@@ -89,6 +89,17 @@ test('send(<Number>)', async t => {
 	}
 });
 
+test('send(204)', async t => {
+	const fn = async (req, res) => {
+		send(res, 204);
+	};
+
+	const url = await getUrl(fn);
+	const res = await request(url, {resolveWithFullResponse: true});
+
+	t.deepEqual(res.headers['content-length'], '0');
+});
+
 test('return <String>', async t => {
 	const fn = async () => 'woot';
 


### PR DESCRIPTION
Automatically sets the `Content-Length` header for when sending `204`'s, since Safari expects it (as seen here: https://github.com/expressjs/cors/blob/master/lib/index.js#L176-L177).

If you don't want to support this, no worries — feel free to close 🙂 