### PR TITLE
Add new programmatic usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,13 +244,14 @@ module.exports = async (req, res) => {
 You can use Micro programmatically by requiring Micro directly:
 
 ```js
+const http = require('http')
 const micro = require('micro')
 const sleep = require('then-sleep')
 
-const server = micro(async (req, res) => {
+const server = new http.Server(micro(async (req, res) => {
   await sleep(500)
   return 'Hello world'
-})
+}))
 
 server.listen(3000)
 ```
@@ -259,7 +260,7 @@ server.listen(3000)
 
 - This function is exposed as the `default` export.
 - Use `require('micro')`.
-- Returns a [`http.Server`](https://nodejs.org/dist/latest-v6.x/docs/api/http.html#http_class_http_server) that uses the provided `function` as the request handler.
+- Returns a function with the `(req, res) => void` signature. That uses the provided `function` as the request handler.
 - The supplied function is run with `await`. So it can be `async`
 
 ##### sendError(req, res, error)
@@ -353,17 +354,18 @@ Micro makes tests compact and a pleasure to read and write.
 We recommend [ava](https://github.com/sindresorhus/ava), a highly parallel Micro test framework with built-in support for async tests:
 
 ```js
+const http = require('http')
 const micro = require('micro')
 const test = require('ava')
 const listen = require('test-listen')
 const request = require('request-promise')
 
 test('my endpoint', async t => {
-  const service = micro(async (req, res) => {
+  const service = new http.Server(micro(async (req, res) => {
     micro.send(res, 200, {
       test: 'woot'
     })
-  })
+  }))
 
   const url = await listen(service)
   const body = await request(url)

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,4 @@
 // Native
-const server = require('http').Server;
 const {Stream} = require('stream');
 
 // Packages
@@ -23,7 +22,7 @@ function readable(stream) {
 const {NODE_ENV} = process.env;
 const DEV = NODE_ENV === 'development';
 
-const serve = fn => server((req, res) => exports.run(req, res, fn));
+const serve = fn => (req, res) => exports.run(req, res, fn);
 
 module.exports = serve;
 exports = serve;

--- a/test/development.js
+++ b/test/development.js
@@ -2,12 +2,13 @@
 const test = require('ava');
 const request = require('request-promise');
 const listen = require('test-listen');
+const http = require('http');
 
 process.env.NODE_ENV = 'development';
 const micro = require('../');
 
 const getUrl = fn => {
-	const srv = micro(fn);
+	const srv = new http.Server(micro(fn));
 
 	return listen(srv);
 };

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,5 @@
 // Packages
+const http = require('http');
 const test = require('ava');
 const request = require('request-promise');
 const sleep = require('then-sleep');
@@ -8,7 +9,11 @@ const micro = require('../');
 
 const {send, sendError, buffer, json} = micro;
 
-const getUrl = fn => listen(micro(fn));
+const getUrl = fn => {
+	const srv = new http.Server(micro(fn));
+
+	return listen(srv);
+};
 
 test('send(200, <String>)', async t => {
 	const fn = async (req, res) => {

--- a/test/production.js
+++ b/test/production.js
@@ -1,4 +1,5 @@
 // Packages
+const http = require('http');
 const test = require('ava');
 const request = require('request-promise');
 const listen = require('test-listen');
@@ -7,7 +8,7 @@ process.env.NODE_ENV = 'production';
 const micro = require('../');
 
 const getUrl = fn => {
-	const srv = micro(fn);
+	const srv = new http.Server(micro(fn));
 
 	return listen(srv);
 };


### PR DESCRIPTION
Related: https://github.com/zeit/next.js/issues/7297

For serverless functions, `@now/node`:

```js
const micro = require('micro')

module.exports = micro((req, res) ⇒ {
   return 'Hello World'
})
```

Current invoking micro() will return a Node.js http.Server which doesn't work well with just `req, res` as a handler. This also ties into using micro standalone with `@now/node`. Doing this will also allow us to deprecate `micro-dev` too in favor of using Next.js / `now dev` + `@now/node`

The new programmatic usage works everywhere and really makes Micro a layer on top of the default Node.js request handling.

This solves:

- Easier usage (no extra steps needed besides installing and using, like setting up the commands in package.json etc is no longer needed)
- Easier deployment
- Scalable by default
- Serverless by default