### PR TITLE
Remove usage of now from socket.io examples

### DIFF
--- a/examples/socket.io-chat-app/README.md
+++ b/examples/socket.io-chat-app/README.md
@@ -19,12 +19,6 @@ npm install
 npm run start
 ```
 
-Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
-
-```bash
-now
-```
-
 ## The idea behind the example
 
-Shows how to make use of socket.io with micro, to deploy on now.
+Shows how to make use of socket.io with micro.

--- a/examples/with-https/README.md
+++ b/examples/with-https/README.md
@@ -16,12 +16,6 @@ npm install
 npm run start
 ```
 
-Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
-
-```bash
-now
-```
-
 ## The idea behind the example
 
 Shows how to make use of HTTPS requests with micro.


### PR DESCRIPTION
Now2.0 is not support socket.io, so I remove how to deploy socket.io app with Now. ( #377 )