### PR TITLE
On socket.io examples, deploy for Now1.0

### DIFF
--- a/examples/socket.io-chat-app/now.json
+++ b/examples/socket.io-chat-app/now.json
@@ -1,0 +1,5 @@
+{
+  "name": "socketio-chat-app",
+  "version": 1,
+  "type": "npm"
+}


### PR DESCRIPTION
Add `now.json` to deploy for Now1.0. (socket.io doesn't works on Now2.0)