### PR TITLE
Gracefully shutdown: exit after server is closed

### DIFF
--- a/packages/micro/bin/micro.js
+++ b/packages/micro/bin/micro.js
@@ -205,7 +205,10 @@ function startEndpoint(module, endpoint) {
 	server.listen(...endpoint, () => {
 		const details = server.address();
 
-		registerShutdown(() => server.close());
+		registerShutdown(() => {
+			server.close();
+	        process.exit();
+		});
 
 		// `micro` is designed to run only in production, so
 		// this message is perfectly for prod

--- a/packages/micro/bin/micro.js
+++ b/packages/micro/bin/micro.js
@@ -204,7 +204,6 @@ function startEndpoint(module, endpoint) {
 
 	server.listen(...endpoint, () => {
 		const details = server.address();
-		
 		registerShutdown(() => {
 			console.log('micro: Gracefully shutting down. Please wait...');
 			server.close();

--- a/packages/micro/bin/micro.js
+++ b/packages/micro/bin/micro.js
@@ -206,7 +206,7 @@ function startEndpoint(module, endpoint) {
 		const details = server.address();
 		
 		registerShutdown(() => {
-			console.log('micro: Gracefully shutting down. Please wait...')
+			console.log('micro: Gracefully shutting down. Please wait...');
 			server.close();
 	        process.exit();
 		});

--- a/packages/micro/bin/micro.js
+++ b/packages/micro/bin/micro.js
@@ -204,8 +204,9 @@ function startEndpoint(module, endpoint) {
 
 	server.listen(...endpoint, () => {
 		const details = server.address();
-
+		
 		registerShutdown(() => {
+			console.log('micro: Gracefully shutting down. Please wait...')
 			server.close();
 	        process.exit();
 		});
@@ -228,8 +229,6 @@ async function start() {
 	for (const endpoint of args['--listen']) {
 		startEndpoint(loadedModule, endpoint);
 	}
-
-	registerShutdown(() => console.log('micro: Gracefully shutting down. Please wait...'));
 }
 
 start();


### PR DESCRIPTION
If `process.exit()` is not called explicitly, the server is still waiting a kill signal

Closes #407