### PR TITLE
Remove request-promise (deprecation)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "node-fetch": "2.6.0",
     "lerna": "^3.4.0",
     "@zeit/eslint-config-node": "0.2.13",
     "@zeit/git-hooks": "0.1.4",
@@ -20,8 +21,6 @@
     "eslint": "4.19.1",
     "husky": "0.14.3",
     "nyc": "11.3.0",
-    "request": "2.83.0",
-    "request-promise": "4.2.2",
     "resumer": "0.0.0",
     "rewire": "3.0.2",
     "sinon": "4.4.3",

--- a/packages/micro/README.md
+++ b/packages/micro/README.md
@@ -338,7 +338,7 @@ const http = require('http')
 const micro = require('micro')
 const test = require('ava')
 const listen = require('test-listen')
-const request = require('request-promise')
+const fetch = require('node-fetch')
 
 test('my endpoint', async t => {
   const service = new http.Server(micro(async (req, res) => {
@@ -348,9 +348,10 @@ test('my endpoint', async t => {
   }))
 
   const url = await listen(service)
-  const body = await request(url)
+  const response = await fetch(url)
+  const body = await response.json()
 
-  t.deepEqual(JSON.parse(body).test, 'woot')
+  t.deepEqual(body.test, 'woot')
   service.close()
 })
 ```

--- a/test/development.js
+++ b/test/development.js
@@ -1,6 +1,6 @@
 // Packages
 const test = require('ava');
-const request = require('request-promise');
+const fetch = require('node-fetch');
 const listen = require('test-listen');
 const http = require('http');
 
@@ -17,9 +17,10 @@ test('send(200, <Object>) is pretty-printed', async t => {
 	const fn = () => ({woot: 'yes'});
 
 	const url = await getUrl(fn);
-	const res = await request(url);
+	const res = await fetch(url);
+	const body = await res.text();
 
-	t.deepEqual(res, `{\n  "woot": "yes"\n}`);
+	t.deepEqual(body, `{\n  "woot": "yes"\n}`);
 });
 
 test('sendError shows stack in development without statusCode', async t => {
@@ -28,11 +29,9 @@ test('sendError shows stack in development without statusCode', async t => {
 	};
 
 	const url = await getUrl(fn);
-	try {
-		await request(url);
-	} catch (err) {
-		t.true(err.message.indexOf('at fn (') !== -1);
-	}
+	const res = await fetch(url);
+	const body = await res.text();
+	t.true(body.indexOf('at fn (') !== -1);
 });
 
 test('sendError shows stack in development with statusCode', async t => {
@@ -43,9 +42,7 @@ test('sendError shows stack in development with statusCode', async t => {
 	};
 
 	const url = await getUrl(fn);
-	try {
-		await request(url);
-	} catch (err) {
-		t.true(err.message.indexOf('at fn (') !== -1);
-	}
+	const res = await fetch(url);
+	const body = await res.text();
+	t.true(body.indexOf('at fn (') !== -1);
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 // Packages
 const http = require('http');
 const test = require('ava');
-const request = require('request-promise');
+const fetch = require('node-fetch');
 const sleep = require('then-sleep');
 const resumer = require('resumer');
 const listen = require('test-listen');
@@ -21,9 +21,10 @@ test('send(200, <String>)', async t => {
 	};
 
 	const url = await getUrl(fn);
-	const res = await request(url);
+	const res = await fetch(url);
+	const body = await res.text();
 
-	t.deepEqual(res, 'woot');
+	t.deepEqual(body, 'woot');
 });
 
 test('send(200, <Object>)', async t => {
@@ -35,9 +36,7 @@ test('send(200, <Object>)', async t => {
 
 	const url = await getUrl(fn);
 
-	const res = await request(url, {
-		json: true
-	});
+	const res = await fetch(url).then(r => r.json());
 
 	t.deepEqual(res, {
 		a: 'b'
@@ -51,9 +50,7 @@ test('send(200, <Number>)', async t => {
 	};
 
 	const url = await getUrl(fn);
-	const res = await request(url, {
-		json: true
-	});
+	const res = await fetch(url).then(r => r.json());
 
 	t.deepEqual(res, 4);
 });
@@ -64,7 +61,7 @@ test('send(200, <Buffer>)', async t => {
 	};
 
 	const url = await getUrl(fn);
-	const res = await request(url);
+	const res = await fetch(url).then(r => r.text());
 
 	t.deepEqual(res, 'muscle');
 });
@@ -75,7 +72,7 @@ test('send(200, <Stream>)', async t => {
 	};
 
 	const url = await getUrl(fn);
-	const res = await request(url);
+	const res = await fetch(url).then(r => r.text());
 
 	t.deepEqual(res, 'waterfall');
 });
@@ -87,18 +84,15 @@ test('send(<Number>)', async t => {
 
 	const url = await getUrl(fn);
 
-	try {
-		await request(url);
-	} catch (err) {
-		t.deepEqual(err.statusCode, 404);
-	}
+	const {status} = await fetch(url);
+	t.deepEqual(status, 404);
 });
 
 test('return <String>', async t => {
 	const fn = async () => 'woot';
 
 	const url = await getUrl(fn);
-	const res = await request(url);
+	const res = await fetch(url).then(r => r.text());
 
 	t.deepEqual(res, 'woot');
 });
@@ -110,7 +104,7 @@ test('return <Promise>', async t => {
 	});
 
 	const url = await getUrl(fn);
-	const res = await request(url);
+	const res = await fetch(url).then(r => r.text());
 
 	t.deepEqual(res, 'I Promise');
 });
@@ -119,7 +113,7 @@ test('sync return <String>', async t => {
 	const fn = () => 'argon';
 
 	const url = await getUrl(fn);
-	const res = await request(url);
+	const res = await fetch(url).then(r => r.text());
 
 	t.deepEqual(res, 'argon');
 });
@@ -128,7 +122,7 @@ test('return empty string', async t => {
 	const fn = async () => '';
 
 	const url = await getUrl(fn);
-	const res = await request(url);
+	const res = await fetch(url).then(r => r.text());
 
 	t.deepEqual(res, '');
 });
@@ -139,9 +133,7 @@ test('return <Object>', async t => {
 	});
 
 	const url = await getUrl(fn);
-	const res = await request(url, {
-		json: true
-	});
+	const res = await fetch(url).then(r => r.json());
 
 	t.deepEqual(res, {
 		a: 'b'
@@ -155,9 +147,7 @@ test('return <Number>', async t => {
 
 
 	const url = await getUrl(fn);
-	const res = await request(url, {
-		json: true
-	});
+	const res = await fetch(url).then(r => r.json());
 
 	t.deepEqual(res, 4);
 });
@@ -166,7 +156,7 @@ test('return <Buffer>', async t => {
 	const fn = async () => Buffer.from('Hammer');
 
 	const url = await getUrl(fn);
-	const res = await request(url);
+	const res = await fetch(url).then(r => r.text());
 
 	t.deepEqual(res, 'Hammer');
 });
@@ -178,7 +168,7 @@ test('return <Stream>', async t => {
 			.end();
 
 	const url = await getUrl(fn);
-	const res = await request(url);
+	const res = await fetch(url).then(r => r.text());
 
 	t.deepEqual(res, 'River');
 });
@@ -187,10 +177,11 @@ test('return <null>', async t => {
 	const fn = async () => null;
 
 	const url = await getUrl(fn);
-	const res = await request(url, {resolveWithFullResponse: true});
+	const res = await fetch(url);
+	const body = await res.text();
 
-	t.is(res.statusCode, 204);
-	t.is(res.body, '');
+	t.is(res.status, 204);
+	t.is(body, '');
 });
 
 test('return <null> calls res.end once', async t => {
@@ -212,11 +203,9 @@ test('throw with code', async t => {
 
 	const url = await getUrl(fn);
 
-	try {
-		await request(url);
-	} catch (err) {
-		t.deepEqual(err.statusCode, 402);
-	}
+	const {status} = await fetch(url);
+
+	t.deepEqual(status, 402);
 });
 
 test('throw (500)', async t => {
@@ -226,11 +215,8 @@ test('throw (500)', async t => {
 
 	const url = await getUrl(fn);
 
-	try {
-		await request(url);
-	} catch (err) {
-		t.deepEqual(err.statusCode, 500);
-	}
+	const {status} = await fetch(url);
+	t.deepEqual(status, 500);
 });
 
 test('throw (500) sync', async t => {
@@ -240,11 +226,8 @@ test('throw (500) sync', async t => {
 
 	const url = await getUrl(fn);
 
-	try {
-		await request(url);
-	} catch (err) {
-		t.deepEqual(err.statusCode, 500);
-	}
+	const {status} = await fetch(url);
+	t.deepEqual(status, 500);
 });
 
 test('send(200, <Stream>) with error on same tick', async t => {
@@ -258,12 +241,8 @@ test('send(200, <Stream>) with error on same tick', async t => {
 
 	const url = await getUrl(fn);
 
-	try {
-		await request(url);
-		t.fail();
-	} catch (err) {
-		t.deepEqual(err.statusCode, 500);
-	}
+	const {status} = await fetch(url);
+	t.deepEqual(status, 500);
 });
 
 test('send(200, <Stream>) custom stream', async t => {
@@ -290,12 +269,8 @@ test('send(200, <Stream>) custom stream', async t => {
 
 	const url = await getUrl(fn);
 
-	try {
-		await request(url);
-		t.fail();
-	} catch (err) {
-		t.deepEqual(err.statusCode, 500);
-	}
+	const {status} = await fetch(url);
+	t.deepEqual(status, 500);
 });
 
 test('custom error', async t => {
@@ -313,7 +288,7 @@ test('custom error', async t => {
 	};
 
 	const url = await getUrl(handleErrors(fn));
-	const res = await request(url);
+	const res = await fetch(url).then(r => r.text());
 
 	t.deepEqual(res, 'My custom error!');
 });
@@ -333,7 +308,7 @@ test('custom async error', async t => {
 	};
 
 	const url = await getUrl(handleErrors(fn));
-	const res = await request(url);
+	const res = await fetch(url).then(r => r.text());
 
 	t.deepEqual(res, 'My custom error!');
 });
@@ -346,17 +321,14 @@ test('json parse error', async t => {
 
 	const url = await getUrl(fn);
 
-	try {
-		await request(url, {
-			method: 'POST',
-			body: '{ "bad json" }',
-			headers: {
-				'Content-Type': 'application/json'
-			}
-		});
-	} catch (err) {
-		t.deepEqual(err.statusCode, 400);
-	}
+	const {status} = await fetch(url, {
+		method: 'POST',
+		body: '{ "bad json" }',
+		headers: {
+			'Content-Type': 'application/json'
+		}
+	});
+	t.deepEqual(status, 400);
 });
 
 test('json', async t => {
@@ -370,15 +342,15 @@ test('json', async t => {
 
 	const url = await getUrl(fn);
 
-	const body = await request(url, {
+	const res = await fetch(url, {
 		method: 'POST',
-		body: {
+		body: JSON.stringify({
 			some: {
 				cool: 'json'
 			}
-		},
-		json: true
+		})
 	});
+	const body = await res.json();
 
 	t.deepEqual(body.response, 'json');
 });
@@ -396,15 +368,15 @@ test('json limit (below)', async t => {
 
 	const url = await getUrl(fn);
 
-	const body = await request(url, {
+	const res = await fetch(url, {
 		method: 'POST',
-		body: {
+		body: JSON.stringify({
 			some: {
 				cool: 'json'
 			}
-		},
-		json: true
+		})
 	});
+	const body = await res.json();
 
 	t.deepEqual(body.response, 'json');
 });
@@ -423,15 +395,15 @@ test('json limit (over)', async t => {
 	};
 
 	const url = await getUrl(fn);
-	await request(url, {
+	const res = await fetch(url, {
 		method: 'POST',
-		body: {
+		body: JSON.stringify({
 			some: {
 				cool: 'json'
 			}
-		},
-		json: true
+		})
 	});
+	t.deepEqual(res.status, 200);
 });
 
 test('json circular', async t => {
@@ -446,13 +418,8 @@ test('json circular', async t => {
 
 	const url = await getUrl(fn);
 
-	try {
-		await request(url, {
-			json: true
-		});
-	} catch (err) {
-		t.deepEqual(err.statusCode, 500);
-	}
+	const {status} = await fetch(url);
+	t.deepEqual(status, 500);
 });
 
 test('no async', async t => {
@@ -463,9 +430,7 @@ test('no async', async t => {
 	};
 
 	const url = await getUrl(fn);
-	const obj = await request(url, {
-		json: true
-	});
+	const obj = await fetch(url).then(r => r.json());
 
 	t.deepEqual(obj.a, 'b');
 });
@@ -488,17 +453,16 @@ test('limit included in error', async t => {
 	};
 
 	const url = await getUrl(fn);
-	const requestPromise = request(url, {
+	const res = await fetch(url, {
 		method: 'POST',
-		body: {
+		body: JSON.stringify({
 			some: {
 				cool: 'json'
 			}
-		},
-		json: true
+		})
 	});
 
-	await t.throws(requestPromise);
+	t.deepEqual(res.status, 500);
 });
 
 test('support for status fallback in errors', async t => {
@@ -509,11 +473,8 @@ test('support for status fallback in errors', async t => {
 	};
 
 	const url = await getUrl(fn);
-	try {
-		await request(url);
-	} catch (err) {
-		t.deepEqual(err.statusCode, 403);
-	}
+	const {status} = await fetch(url);
+	t.deepEqual(status, 403);
 });
 
 test('support for non-Error errors', async t => {
@@ -523,11 +484,8 @@ test('support for non-Error errors', async t => {
 	};
 
 	const url = await getUrl(fn);
-	try {
-		await request(url);
-	} catch (err) {
-		t.deepEqual(err.statusCode, 500);
-	}
+	const {status} = await fetch(url);
+	t.deepEqual(status, 500);
 });
 
 test('json from rawBodyMap works', async t => {
@@ -543,15 +501,15 @@ test('json from rawBodyMap works', async t => {
 	};
 
 	const url = await getUrl(fn);
-	const body = await request(url, {
+	const res = await fetch(url, {
 		method: 'POST',
-		body: {
+		body: JSON.stringify({
 			some: {
 				cool: 'json'
 			}
-		},
-		json: true
+		})
 	});
+	const body = await res.json();
 
 	t.deepEqual(body.response, 'json');
 });
@@ -564,9 +522,10 @@ test('statusCode defaults to 200', async t => {
 	};
 
 	const url = await getUrl(fn);
-	const res = await request(url, {resolveWithFullResponse: true});
-	t.is(res.body, 'woot');
-	t.is(res.statusCode, 200);
+	const res = await fetch(url);
+	const body = await res.text();
+	t.is(body, 'woot');
+	t.is(res.status, 200);
 });
 
 test('statusCode on response works', async t => {
@@ -577,11 +536,8 @@ test('statusCode on response works', async t => {
 
 	const url = await getUrl(fn);
 
-	try {
-		await request(url);
-	} catch (err) {
-		t.deepEqual(err.statusCode, 400);
-	}
+	const {status} = await fetch(url);
+	t.deepEqual(status, 400);
 });
 
 test('Content-Type header is preserved on string', async t => {
@@ -591,9 +547,9 @@ test('Content-Type header is preserved on string', async t => {
 	};
 
 	const url = await getUrl(fn);
-	const res = await request(url, {resolveWithFullResponse: true});
+	const res = await fetch(url);
 
-	t.is(res.headers['content-type'], 'text/html');
+	t.is(res.headers.get('content-type'), 'text/html');
 });
 
 test('Content-Type header is preserved on stream', async t => {
@@ -605,9 +561,9 @@ test('Content-Type header is preserved on stream', async t => {
 	};
 
 	const url = await getUrl(fn);
-	const res = await request(url, {resolveWithFullResponse: true});
+	const res = await fetch(url);
 
-	t.is(res.headers['content-type'], 'text/html');
+	t.is(res.headers.get('content-type'), 'text/html');
 });
 
 test('Content-Type header is preserved on buffer', async t => {
@@ -617,9 +573,9 @@ test('Content-Type header is preserved on buffer', async t => {
 	};
 
 	const url = await getUrl(fn);
-	const res = await request(url, {resolveWithFullResponse: true});
+	const res = await fetch(url);
 
-	t.is(res.headers['content-type'], 'text/html');
+	t.is(res.headers.get('content-type'), 'text/html');
 });
 
 test('Content-Type header is preserved on object', async t => {
@@ -629,9 +585,9 @@ test('Content-Type header is preserved on object', async t => {
 	};
 
 	const url = await getUrl(fn);
-	const res = await request(url, {resolveWithFullResponse: true});
+	const res = await fetch(url);
 
-	t.is(res.headers['content-type'], 'text/html');
+	t.is(res.headers.get('content-type'), 'text/html');
 });
 
 test('res.end is working', async t => {
@@ -640,7 +596,7 @@ test('res.end is working', async t => {
 	};
 
 	const url = await getUrl(fn);
-	const res = await request(url);
+	const res = await fetch(url).then(r => r.text());
 
 	t.deepEqual(res, 'woot');
 });
@@ -650,12 +606,10 @@ test('json should throw 400 on empty body with no headers', async t => {
 
 	const url = await getUrl(fn);
 
-	try {
-		await request(url);
-	} catch (err) {
-		t.is(err.message, '400 - "Invalid JSON"');
-		t.is(err.statusCode, 400);
-	}
+	const res = await fetch(url);
+	const body = await res.text();
+	t.is(body, 'Invalid JSON');
+	t.is(res.status, 400);
 });
 
 test('buffer should throw 400 on invalid encoding', async t => {
@@ -663,26 +617,26 @@ test('buffer should throw 400 on invalid encoding', async t => {
 
 	const url = await getUrl(fn);
 
-	try {
-		await request(url, {
-			method: 'POST',
-			body: '❤️'
-		});
-	} catch (err) {
-		t.is(err.message, '400 - "Invalid body"');
-		t.is(err.statusCode, 400);
-	}
+	const res = await fetch(url, {
+		method: 'POST',
+		body: '❤️'
+	});
+	const body = await res.text();
+	t.is(body, 'Invalid body');
+	t.is(res.status, 400);
 });
 
 test('buffer works', async t => {
 	const fn = async req => buffer(req);
 	const url = await getUrl(fn);
-	t.is(await request(url, {body: '❤️'}), '❤️');
+	const res = await fetch(url, {method: 'POST', body: '❤️'});
+	const body = await res.text();
+	t.is(body, '❤️');
 });
 
 test('Content-Type header for JSON is set', async t => {
 	const url = await getUrl(() => ({}));
-	const res = await request(url, {resolveWithFullResponse: true});
+	const res = await fetch(url);
 
-	t.is(res.headers['content-type'], 'application/json; charset=utf-8');
+	t.is(res.headers.get('content-type'), 'application/json; charset=utf-8');
 });

--- a/test/production.js
+++ b/test/production.js
@@ -1,7 +1,7 @@
 // Packages
 const http = require('http');
 const test = require('ava');
-const request = require('request-promise');
+const fetch = require('node-fetch');
 const listen = require('test-listen');
 
 process.env.NODE_ENV = 'production';
@@ -25,11 +25,8 @@ test.serial('errors are printed in console in production', async t => {
 	};
 
 	const url = await getUrl(fn);
-	try {
-		await request(url);
-	} catch (err) {
-		t.true(logged);
-		t.deepEqual(err.statusCode, 500);
-		console.error = _error;
-	}
+	const res = await fetch(url);
+	t.true(logged);
+	t.deepEqual(res.status, 500);
+	console.error = _error;
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -838,7 +838,7 @@ ajv-keywords@^2.1.0:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
   integrity sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=
 
-ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
+ajv@^5.2.3, ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   integrity sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=
@@ -1185,7 +1185,7 @@ aws-sign2@~0.7.0:
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
   integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
 
-aws4@^1.6.0, aws4@^1.8.0:
+aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
@@ -1560,24 +1560,10 @@ binary-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
-bluebird@^3.0.0, bluebird@^3.5.0, bluebird@^3.5.1, bluebird@^3.5.3:
+bluebird@^3.0.0, bluebird@^3.5.1, bluebird@^3.5.3:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.4.tgz#d6cc661595de30d5b3af5fcedd3c0b3ef6ec5714"
   integrity sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==
-
-boom@4.x.x:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-4.3.1.tgz#4f8a3005cb4a7e3889f749030fd25b96e01d2e31"
-  integrity sha1-T4owBctKfjiJ90kDD9JbluAdLjE=
-  dependencies:
-    hoek "4.x.x"
-
-boom@5.x.x:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-5.2.0.tgz#5dd9da6ee3a5f302077436290cb717d3f4a54e02"
-  integrity sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==
-  dependencies:
-    hoek "4.x.x"
 
 boxen@^1.2.1:
   version "1.3.0"
@@ -1991,7 +1977,7 @@ columnify@^1.5.4:
     strip-ansi "^3.0.0"
     wcwidth "^1.0.0"
 
-combined-stream@^1.0.6, combined-stream@~1.0.5, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
   integrity sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==
@@ -2272,13 +2258,6 @@ cross-spawn@^6.0.0:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
-
-cryptiles@3.x.x:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.4.tgz#769a68c95612b56faadfcebf57ac86479cbe8322"
-  integrity sha512-8I1sgZHfVwcSOY6mSGpVU3lw/GSIZvusg8dD2+OGehCJpOhQRLNcH0qb9upQnOH4XhgxxFJSg6E2kx95deb1Tw==
-  dependencies:
-    boom "5.x.x"
 
 crypto-random-string@^1.0.0:
   version "1.0.0"
@@ -2792,7 +2771,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@~3.0.1, extend@~3.0.2:
+extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -3017,7 +2996,7 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-form-data@~2.3.1, form-data@~2.3.2:
+form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
   integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
@@ -3327,14 +3306,6 @@ har-schema@^2.0.0:
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
   integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
 
-har-validator@~5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd"
-  integrity sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=
-  dependencies:
-    ajv "^5.1.0"
-    har-schema "^2.0.0"
-
 har-validator@~5.1.0:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.3.tgz#1ef89ebd3e4996557675eed9893110dc350fa080"
@@ -3410,21 +3381,6 @@ has-yarn@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-yarn/-/has-yarn-1.0.0.tgz#89e25db604b725c8f5976fff0addc921b828a5a7"
   integrity sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac=
-
-hawk@~6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
-  integrity sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==
-  dependencies:
-    boom "4.x.x"
-    cryptiles "3.x.x"
-    hoek "4.x.x"
-    sntp "2.x.x"
-
-hoek@4.x.x:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
-  integrity sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -3683,11 +3639,6 @@ invert-kv@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
-
-ip-regex@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
-  integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
 
 ip@^1.1.5:
   version "1.1.5"
@@ -4427,7 +4378,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.13.1, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0:
+lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -4663,7 +4614,7 @@ mime-db@1.40.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
   integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
 
-mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19:
+mime-types@^2.1.12, mime-types@~2.1.19:
   version "2.1.24"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.24.tgz#b6f8d0b3e951efb77dedeca194cff6d16f676f81"
   integrity sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==
@@ -4874,6 +4825,11 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
+node-fetch@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
 node-fetch@^2.3.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.5.0.tgz#8028c49fc1191bba56a07adc6e2a954644a48501"
@@ -5066,11 +5022,6 @@ nyc@11.3.0:
     test-exclude "^4.1.1"
     yargs "^10.0.3"
     yargs-parser "^8.0.0"
-
-oauth-sign@~0.8.2:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
-  integrity sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=
 
 oauth-sign@~0.9.0:
   version "0.9.0"
@@ -5654,7 +5605,7 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
-psl@^1.1.24, psl@^1.1.28:
+psl@^1.1.24:
   version "1.1.31"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.31.tgz#e9aa86d0101b5b105cbe93ac6b784cd547276184"
   integrity sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==
@@ -5689,7 +5640,7 @@ punycode@^1.4.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
-punycode@^2.1.0, punycode@^2.1.1:
+punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
@@ -5699,7 +5650,7 @@ q@^1.5.1:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
-qs@~6.5.1, qs@~6.5.2:
+qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
@@ -5977,51 +5928,6 @@ repeating@^2.0.0:
   integrity sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=
   dependencies:
     is-finite "^1.0.0"
-
-request-promise-core@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
-  integrity sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=
-  dependencies:
-    lodash "^4.13.1"
-
-request-promise@4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.2.tgz#d1ea46d654a6ee4f8ee6a4fea1018c22911904b4"
-  integrity sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=
-  dependencies:
-    bluebird "^3.5.0"
-    request-promise-core "1.1.1"
-    stealthy-require "^1.1.0"
-    tough-cookie ">=2.3.3"
-
-request@2.83.0:
-  version "2.83.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
-  integrity sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==
-  dependencies:
-    aws-sign2 "~0.7.0"
-    aws4 "^1.6.0"
-    caseless "~0.12.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.1"
-    forever-agent "~0.6.1"
-    form-data "~2.3.1"
-    har-validator "~5.0.3"
-    hawk "~6.0.2"
-    http-signature "~1.2.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.17"
-    oauth-sign "~0.8.2"
-    performance-now "^2.1.0"
-    qs "~6.5.1"
-    safe-buffer "^5.1.1"
-    stringstream "~0.0.5"
-    tough-cookie "~2.3.3"
-    tunnel-agent "^0.6.0"
-    uuid "^3.1.0"
 
 request@^2.87.0:
   version "2.88.0"
@@ -6341,13 +6247,6 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-sntp@2.x.x:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/sntp/-/sntp-2.1.0.tgz#2c6cec14fedc2222739caf9b5c3d85d1cc5a2cc8"
-  integrity sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==
-  dependencies:
-    hoek "4.x.x"
-
 socks-proxy-agent@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz#3c8991f3145b2799e70e11bd5fbc8b1963116386"
@@ -6508,11 +6407,6 @@ static-extend@^0.1.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
-stealthy-require@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
-  integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
-
 stream-each@^1.1.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/stream-each/-/stream-each-1.2.3.tgz#ebe27a0c389b04fbcc233642952e10731afa9bae"
@@ -6556,11 +6450,6 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
-
-stringstream@~0.0.5:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.6.tgz#7880225b0d4ad10e30927d167a1d6f2fd3b33a72"
-  integrity sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
@@ -6838,22 +6727,6 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
-tough-cookie@>=2.3.3:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-3.0.1.tgz#9df4f57e739c26930a018184887f4adb7dca73b2"
-  integrity sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==
-  dependencies:
-    ip-regex "^2.1.0"
-    psl "^1.1.28"
-    punycode "^2.1.1"
-
-tough-cookie@~2.3.3:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
-  integrity sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==
-  dependencies:
-    punycode "^1.4.1"
-
 tough-cookie@~2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
@@ -7066,7 +6939,7 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2:
+uuid@^3.0.1, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==


### PR DESCRIPTION
Good morning everyone.

The package "request" is deprecated.
The package 'request-promise" relies on "request".

This pull request replaces "request-promise" and uses "node-fetch" instead.