### PR TITLE
Remove duplicated code "getUrl" (tests)

### DIFF
--- a/test/_test-utils.js
+++ b/test/_test-utils.js
@@ -1,0 +1,3 @@
+module.exports = ({http, micro, listen}) => ({
+	getUrl: fn => listen(new http.Server(micro(fn)))
+});

--- a/test/development.js
+++ b/test/development.js
@@ -7,11 +7,7 @@ const http = require('http');
 process.env.NODE_ENV = 'development';
 const micro = require('../packages/micro/lib');
 
-const getUrl = fn => {
-	const srv = new http.Server(micro(fn));
-
-	return listen(srv);
-};
+const {getUrl} = require('./_test-utils')({http, micro, listen});
 
 test('send(200, <Object>) is pretty-printed', async t => {
 	const fn = () => ({woot: 'yes'});

--- a/test/index.js
+++ b/test/index.js
@@ -6,14 +6,9 @@ const sleep = require('then-sleep');
 const resumer = require('resumer');
 const listen = require('test-listen');
 const micro = require('../packages/micro/lib');
+const {getUrl} = require('./_test-utils')({http, micro, listen});
 
 const {send, sendError, buffer, json} = micro;
-
-const getUrl = fn => {
-	const srv = new http.Server(micro(fn));
-
-	return listen(srv);
-};
 
 test('send(200, <String>)', async t => {
 	const fn = async (req, res) => {

--- a/test/production.js
+++ b/test/production.js
@@ -7,11 +7,7 @@ const listen = require('test-listen');
 process.env.NODE_ENV = 'production';
 const micro = require('../packages/micro');
 
-const getUrl = fn => {
-	const srv = new http.Server(micro(fn));
-
-	return listen(srv);
-};
+const {getUrl} = require('./_test-utils')({http, micro, listen});
 
 test.serial('errors are printed in console in production', async t => {
 	let logged = false;


### PR DESCRIPTION
Very small improvement.

Good to know: ava consider files starting with a `_` to be helper files.
Therefore, the `_test-utils.js` file is not "asserted".

Interesting: I decided to use a closure (dependency injection) because micro requires the NODE_ENV to be set before import.