### PR TITLE
Revert "Native ES modules import for .mjs"

### DIFF
--- a/packages/micro/lib/handler.js
+++ b/packages/micro/lib/handler.js
@@ -5,7 +5,7 @@ module.exports = async file => {
 	let mod;
 
 	try {
-		mod = file.endsWith('.mjs') ? await import(file) : await require(file); // Await to support exporting Promises
+		mod = await require(file); // Await to support exporting Promises
 
 		if (mod && typeof mod === 'object') {
 			mod = await mod.default; // Await to support es6 module's default export


### PR DESCRIPTION
Reverts vercel/micro#448

Since this is failing tests, I don't want to merge this into the minor release. I'd like to tackle this with a major version.