### PR TITLE
Bring back default http server wrapper

### DIFF
--- a/packages/micro/README.md
+++ b/packages/micro/README.md
@@ -214,18 +214,15 @@ module.exports = async (req, res) => {
 You can use Micro programmatically by requiring Micro directly:
 
 ```js
-const http = require('http');
-const micro = require('micro');
-const sleep = require('then-sleep');
+const micro = require('micro')
+const sleep = require('then-sleep')
 
-const server = new http.Server(
-  micro(async (req, res) => {
-    await sleep(500);
-    return 'Hello world';
-  })
-);
+const server = micro(async (req, res) => {
+  await sleep(500)
+  return 'Hello world'
+})
 
-server.listen(3000);
+server.listen(3000)
 ```
 
 ##### micro(fn)

--- a/packages/micro/lib/index.js
+++ b/packages/micro/lib/index.js
@@ -1,4 +1,5 @@
 // Native
+const server = require('http').Server;
 const {Stream} = require('stream');
 
 // Packages
@@ -22,7 +23,7 @@ function readable(stream) {
 const {NODE_ENV} = process.env;
 const DEV = NODE_ENV === 'development';
 
-const serve = fn => (req, res) => exports.run(req, res, fn);
+const serve = fn => server((req, res) => exports.run(req, res, fn));
 
 module.exports = serve;
 exports = serve;

--- a/packages/micro/lib/index.js
+++ b/packages/micro/lib/index.js
@@ -1,5 +1,5 @@
 // Native
-const server = require('http').Server;
+const http = require('http');
 const {Stream} = require('stream');
 
 // Packages
@@ -23,7 +23,7 @@ function readable(stream) {
 const {NODE_ENV} = process.env;
 const DEV = NODE_ENV === 'development';
 
-const serve = fn => server((req, res) => exports.run(req, res, fn));
+const serve = fn => new http.Server((req, res) => exports.run(req, res, fn));
 
 module.exports = serve;
 exports = serve;

--- a/test/_test-utils.js
+++ b/test/_test-utils.js
@@ -1,3 +1,3 @@
-module.exports = ({http, micro, listen}) => ({
-	getUrl: fn => listen(new http.Server(micro(fn)))
+module.exports = ({ micro, listen }) => ({
+  getUrl: (fn) => listen(micro(fn)),
 });

--- a/test/development.js
+++ b/test/development.js
@@ -2,12 +2,11 @@
 const test = require('ava');
 const fetch = require('node-fetch');
 const listen = require('test-listen');
-const http = require('http');
 
 process.env.NODE_ENV = 'development';
 const micro = require('../packages/micro/lib');
 
-const {getUrl} = require('./_test-utils')({http, micro, listen});
+const {getUrl} = require('./_test-utils')({micro, listen});
 
 test('send(200, <Object>) is pretty-printed', async t => {
 	const fn = () => ({woot: 'yes'});

--- a/test/index.js
+++ b/test/index.js
@@ -1,12 +1,11 @@
 // Packages
-const http = require('http');
 const test = require('ava');
 const fetch = require('node-fetch');
 const sleep = require('then-sleep');
 const resumer = require('resumer');
 const listen = require('test-listen');
 const micro = require('../packages/micro/lib');
-const {getUrl} = require('./_test-utils')({http, micro, listen});
+const {getUrl} = require('./_test-utils')({micro, listen});
 
 const {send, sendError, buffer, json} = micro;
 

--- a/test/production.js
+++ b/test/production.js
@@ -1,5 +1,4 @@
 // Packages
-const http = require('http');
 const test = require('ava');
 const fetch = require('node-fetch');
 const listen = require('test-listen');
@@ -7,7 +6,7 @@ const listen = require('test-listen');
 process.env.NODE_ENV = 'production';
 const micro = require('../packages/micro');
 
-const {getUrl} = require('./_test-utils')({http, micro, listen});
+const {getUrl} = require('./_test-utils')({micro, listen});
 
 test.serial('errors are printed in console in production', async t => {
 	let logged = false;


### PR DESCRIPTION
The micro has a breaking change in its minor version upgrade from 9.3.4 to 9.4.0 related not to default wrapping the "serve" function result into `http.Server` instance, which leads to "server.listen is not a function" error.

The difference can be seen by comparing the source and README:
- https://www.npmjs.com/package/micro/v/9.3.4#programmatic-use
- https://www.npmjs.com/package/micro/v/9.4.0#programmatic-use

This PR proposes reverting this part of the code and readme to the state from version 9.3.4