### PR TITLE
docs: update README imports

### DIFF
--- a/packages/micro/README.md
+++ b/packages/micro/README.md
@@ -215,7 +215,7 @@ You can use Micro programmatically by requiring Micro directly:
 
 ```js
 const http = require('http');
-const { serve } = require('micro');
+const serve = require('micro');
 const sleep = require('then-sleep');
 
 const server = new http.Server(


### PR DESCRIPTION
Update examples to reflect `serve` as the default export of `micro`