### PR TITLE
Fix require statement in programmatic example

### DIFF
--- a/packages/micro/README.md
+++ b/packages/micro/README.md
@@ -215,8 +215,8 @@ You can use Micro programmatically by requiring Micro directly:
 
 ```js
 const http = require('http');
-const serve = require('micro');
 const sleep = require('then-sleep');
+const { serve } = require('micro');
 
 const server = new http.Server(
   serve(async (req, res) => {


### PR DESCRIPTION
Small little fix for the **programmatic use** example, now the example works without throwing a *serve is not a function* type error.