### PR TITLE
Use pathToFileURL to handle windows file path

### DIFF
--- a/packages/micro/src/lib/handler.ts
+++ b/packages/micro/src/lib/handler.ts
@@ -1,3 +1,5 @@
+// Native
+import { pathToFileURL } from 'url';
 // Utilities
 import { logError } from './error';
 
@@ -5,7 +7,7 @@ export const handle = async (file: string) => {
   let mod: unknown;
 
   try {
-    mod = await import(file);
+    mod = await import(pathToFileURL(file).href);
 
     mod = await (mod as { default: unknown }).default; // use ES6 module's default export
   } catch (err: unknown) {


### PR DESCRIPTION
Related to #474 

Fix `On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'`