### PR TITLE
Fix download URLs

### DIFF
--- a/examples/external-api-call/README.md
+++ b/examples/external-api-call/README.md
@@ -5,7 +5,7 @@
 Download the example [or clone the repo](https://github.com/vercel/micro):
 
 ```bash
-curl https://codeload.github.com/vercel/micro/tar.gz/master | tar -xz --strip=2 micro-master/examples/external-api-call
+curl https://codeload.github.com/vercel/micro/tar.gz/main | tar -xz --strip=2 micro-main/examples/external-api-call
 cd external-api-call
 ```
 

--- a/examples/json-body-parsing/README.md
+++ b/examples/json-body-parsing/README.md
@@ -5,7 +5,7 @@
 Download the example [or clone the repo](https://github.com/vercel/micro):
 
 ```bash
-curl https://codeload.github.com/vercel/micro/tar.gz/master | tar -xz --strip=2 micro-master/examples/json-body-parsing
+curl https://codeload.github.com/vercel/micro/tar.gz/main | tar -xz --strip=2 micro-main/examples/json-body-parsing
 cd json-body-parsing
 ```
 

--- a/examples/socket.io-chat-app/README.md
+++ b/examples/socket.io-chat-app/README.md
@@ -5,7 +5,7 @@
 Download the example [or clone the repo](https://github.com/vercel/micro):
 
 ```bash
-curl https://codeload.github.com/vercel/micro/tar.gz/master | tar -xz --strip=2 micro-master/examples/socket.io-chat-app
+curl https://codeload.github.com/vercel/micro/tar.gz/main | tar -xz --strip=2 micro-main/examples/socket.io-chat-app
 cd socket.io-chat-app
 ```
 

--- a/examples/urlencoded-body-parsing/README.md
+++ b/examples/urlencoded-body-parsing/README.md
@@ -5,7 +5,7 @@
 Download the example [or clone the repo](https://github.com/vercel/micro):
 
 ```bash
-curl https://codeload.github.com/vercel/micro/tar.gz/master | tar -xz --strip=2 micro-master/examples/urlencoded-body-parsing
+curl https://codeload.github.com/vercel/micro/tar.gz/main | tar -xz --strip=2 micro-main/examples/urlencoded-body-parsing
 cd urlencoded-body-parsing
 ```
 

--- a/examples/with-graphql-request/README.md
+++ b/examples/with-graphql-request/README.md
@@ -5,7 +5,7 @@
 Download the example [or clone the repo](https://github.com/vercel/micro):
 
 ```bash
-curl https://codeload.github.com/vercel/micro/tar.gz/master | tar -xz --strip=2 micro-master/examples/with-graphql-request
+curl https://codeload.github.com/vercel/micro/tar.gz/main | tar -xz --strip=2 micro-main/examples/with-graphql-request
 cd with-graphql-request
 ```
 

--- a/examples/with-https/README.md
+++ b/examples/with-https/README.md
@@ -5,7 +5,7 @@
 Download the example [or clone the repo](https://github.com/vercel/micro):
 
 ```bash
-curl https://codeload.github.com/vercel/micro/tar.gz/master | tar -xz --strip=2 micro-master/examples/with-https
+curl https://codeload.github.com/vercel/micro/tar.gz/main | tar -xz --strip=2 micro-main/examples/with-https
 cd socket.io-chat-app
 ```
 


### PR DESCRIPTION
Currently, the download URLs for the examples are using the wrong branch, switching to `main` solves the broken downloads. 