### PR TITLE
Fix External API Call example

### DIFF
--- a/examples/external-api-call/README.md
+++ b/examples/external-api-call/README.md
@@ -16,6 +16,8 @@ npm install
 npm run start
 ```
 
+> **Note** `node-fetch` is limited to the v2.x release when using [CommonJS](https://github.com/node-fetch/node-fetch#commonjs), v3.x and above is ESM-only.
+
 ## The idea behind the example
 
 Shows how to get data from an external api using async/await.

--- a/examples/external-api-call/package.json
+++ b/examples/external-api-call/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "micro": "latest",
-    "node-fetch": "latest"
+    "node-fetch": "release-2.x"
   },
   "author": "",
   "license": "MIT"


### PR DESCRIPTION
This PR fixes the *External API Call* example by limiting `node-fetch` to v2.x, this is due to the latest tag being ESM-only since v3.x. While Micro supports ESM, the examples are all using CommonJS. Making this example not work, with it currently erroring out and throwing an `ERR_REQUIRE_ESM` error.

Also updated the README to include a note as to why `node-fetch` in the example is using the v2.x release tag instead of a newer version.