### PR TITLE
Use pathToFileURL to handle windows file path 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,12 +4,13 @@ on:
   - pull_request
 jobs:
   test:
-    name: Node.js ${{ matrix.node-version }}
-    runs-on: ubuntu-latest
+    name: Node.js ${{ matrix.node-version }} ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         node-version:
           - 16
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/packages/micro/src/lib/handler.ts
+++ b/packages/micro/src/lib/handler.ts
@@ -1,3 +1,5 @@
+// Native
+import { pathToFileURL } from 'url';
 // Utilities
 import { logError } from './error';
 
@@ -5,7 +7,7 @@ export const handle = async (file: string) => {
   let mod: unknown;
 
   try {
-    mod = await import(file);
+    mod = await import(pathToFileURL(file).href);
 
     mod = await (mod as { default: unknown }).default; // use ES6 module's default export
   } catch (err: unknown) {


### PR DESCRIPTION
This PR supersedes https://github.com/vercel/micro/pull/475

## Context

Resolves https://github.com/vercel/micro/issues/474

Windows users get the following error:

> [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'd:'

See failing windows tests without this fix here https://github.com/Marcel-G/micro/actions/runs/5124530825/jobs/9216483962

## Fix

On Windows, absolute paths must be valid file:// URLs.

CC @leerob & @t8g