### PR TITLE
feat: add params to http error

### DIFF
--- a/packages/micro/src/lib/index.ts
+++ b/packages/micro/src/lib/index.ts
@@ -35,9 +35,12 @@ type Serve = (fn: RequestHandler) => RequestListener;
 export const serve: Serve = (fn) => (req, res) => run(req, res, fn);
 
 export class HttpError extends Error {
-  constructor(message: string) {
+  constructor(message: string, params?: { statusCode?: number; originalError?: Error; }) {
     super(message);
     Object.setPrototypeOf(this, HttpError.prototype);
+
+    this.statusCode = params?.statusCode;
+    this.originalError = params?.originalError;
   }
 
   statusCode?: number;


### PR DESCRIPTION
Added the params for more convenient initialization of the error.

Currently, it's only possible to set the status code imperatively like here https://github.com/vercel/micro/blob/9db5838990ef9a7223d0efa9dee9154febd92aeb/test/suite/index.ts#L245